### PR TITLE
Clean Code for bundles/org.eclipse.equinox.common.tests

### DIFF
--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/registry/InputErrorTest.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/registry/InputErrorTest.java
@@ -51,7 +51,7 @@ public class InputErrorTest {
 	 * Use customized registry strategy to both check error processing and to remove
 	 * expected error messages from test log.
 	 */
-	private class RegistryStrategyLog extends RegistryStrategyOSGI {
+	private static class RegistryStrategyLog extends RegistryStrategyOSGI {
 
 		public String msg = null;
 

--- a/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/registry/StaleObjects.java
+++ b/bundles/org.eclipse.equinox.common.tests/src/org/eclipse/equinox/common/tests/registry/StaleObjects.java
@@ -34,7 +34,7 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
 public class StaleObjects {
-	private class HandleCatcher implements IRegistryChangeListener {
+	private static class HandleCatcher implements IRegistryChangeListener {
 		private IExtension extensionFromTheListener;
 
 		public HandleCatcher() {

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
### The following cleanups where applied:

- Make inner classes static where possible

