### PR TITLE
Clean Code for bundles/org.eclipse.equinox.common

### DIFF
--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ReferenceHashSet.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ReferenceHashSet.java
@@ -99,7 +99,7 @@ public class ReferenceHashSet<T> {
 		}
 	}
 
-	private class StrongReference<U> implements HashedReference<U> {
+	private static class StrongReference<U> implements HashedReference<U> {
 		private U referent;
 
 		public StrongReference(U referent, ReferenceQueue<? super U> queue) {

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
### The following cleanups where applied:

- Make inner classes static where possible

