### PR TITLE
Clean Code for bundles/org.eclipse.equinox.region

### DIFF
--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleCollisionHook.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/hook/RegionBundleCollisionHook.java
@@ -96,7 +96,7 @@ public final class RegionBundleCollisionHook implements CollisionHook {
 		collisionCandidates.retainAll(collisions);
 	}
 
-	class VisitorFromTarget extends RegionDigraphVisitorBase<Bundle> {
+	static class VisitorFromTarget extends RegionDigraphVisitorBase<Bundle> {
 
 		VisitorFromTarget(Collection<Bundle> candidates) {
 			super(candidates);
@@ -120,7 +120,7 @@ public final class RegionBundleCollisionHook implements CollisionHook {
 
 	}
 
-	class VisitorFromCandidate extends RegionDigraphVisitorBase<Bundle> {
+	static class VisitorFromCandidate extends RegionDigraphVisitorBase<Bundle> {
 		private final Region targetRegion;
 
 		VisitorFromCandidate(Collection<Bundle> candidates, Region targetRegion) {

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
### The following cleanups where applied:

- Make inner classes static where possible

