### PR TITLE
Clean Code for bundles/org.eclipse.equinox.registry

### DIFF
--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/ExtensionTracker.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/ExtensionTracker.java
@@ -311,7 +311,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 		return (IExtensionPoint target) -> id.equals(target.getNamespaceIdentifier());
 	}
 
-	private class HandlerWrapper {
+	private static class HandlerWrapper {
 		IExtensionChangeHandler handler;
 		IFilter filter;
 

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
### The following cleanups where applied:

- Make inner classes static where possible

