### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.http.registry

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.http.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.registry/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Import-Package: javax.servlet;version="2.3",
  org.osgi.framework;version="1.3.0",
  org.osgi.service.http;version="1.2.0",
  org.osgi.service.packageadmin;version="1.2.0",
- org.osgi.util.tracker;version="1.3.1"
+ org.osgi.util.tracker;version="[1.5.0,2)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.equinox.http.registry;version="1.0.0"
 Bundle-Vendor: %providerName

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Import-Package `org.osgi.util.tracker 1.3.1` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.2` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.http.registry.internal.Activator` and 1 other.

Import-Package `org.osgi.util.tracker 1.3.1` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.3.3` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.http.registry.internal.Activator` and 1 other.


Suggested lower version for package `org.osgi.util.tracker` is `1.5.0` out of [`1.3.3`, `1.4.0`, `1.4.2`, `1.5.0`, `1.5.1`, `1.5.2`, `1.5.3`, `1.5.4`]