### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.http.servletbridge

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Activator: org.eclipse.equinox.http.servletbridge.internal.Activator
 Bundle-Localization: plugin
 Import-Package: javax.servlet.http;version="2.3",
  org.eclipse.equinox.http.servlet;version="1.0.0",
- org.eclipse.equinox.servletbridge;version="1.0.0",
+ org.eclipse.equinox.servletbridge;version="[1.1.0,2)",
  org.osgi.framework;version="1.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.http.servletbridge

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Import-Package `org.eclipse.equinox.servletbridge 1.0.0` (compiled against `1.1.0` provided by `org.eclipse.equinox.servletbridge 1.7.100.v20240327-1824`) includes `1.0.0` (provided by `org.eclipse.equinox.servletbridge 1.0.101.R34x_v20090114-1346`) but this version is missing the method `org/eclipse/equinox/servletbridge/BridgeServlet<span>#</span>registerServletDelegate` referenced by `org.eclipse.equinox.http.servletbridge.internal.Activator`.


Suggested lower version for package `org.eclipse.equinox.servletbridge` is `1.1.0` out of [`1.0.0`, `1.1.0`]