### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.jsp.jasper.registry

### DIFF
--- a/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.registry.Activator
 Import-Package: org.eclipse.equinox.jsp.jasper,
  org.osgi.framework;version="1.3.0",
  org.osgi.service.packageadmin;version="1.2.0",
- org.osgi.util.tracker;version="1.3.0",
+ org.osgi.util.tracker;version="[1.5.0,2)",
  javax.servlet;version="2.4",
  javax.servlet.http;version="2.4"
 Require-Bundle: org.eclipse.equinox.registry,


### PR DESCRIPTION
Import-Package `org.osgi.util.tracker 1.3.0` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.2` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.internal.jsp.jasper.registry.Activator`.

Import-Package `org.osgi.util.tracker 1.3.0` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.3.3` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.internal.jsp.jasper.registry.Activator`.


Suggested lower version for package `org.osgi.util.tracker` is `1.5.0` out of [`1.3.3`, `1.4.0`, `1.4.2`, `1.5.0`, `1.5.1`, `1.5.2`, `1.5.3`, `1.5.4`]