### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.jsp.jasper

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
@@ -11,9 +11,9 @@ Import-Package: com.sun.el;version="3.0.0",
  javax.servlet.descriptor;version="[2.6.0,5.0.0)",
  javax.servlet.http;version="[2.4,5.0)",
  org.apache.jasper.servlet;version="[9,10)",
- org.osgi.framework;version="1.3.0",
+ org.osgi.framework;version="[1.5.0,2)",
  org.osgi.service.packageadmin;version="1.2.0",
- org.osgi.util.tracker;version="1.3.1"
+ org.osgi.util.tracker;version="[1.5.0,2)"
 Export-Package: org.eclipse.equinox.jsp.jasper;version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/features/org.eclipse.equinox.server.jetty/feature.xml
+++ b/features/org.eclipse.equinox.server.jetty/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.equinox.server.jetty"
       label="%featureName"
-      version="1.11.500.qualifier"
+      version="1.11.600.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">


### PR DESCRIPTION
Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/FrameworkUtil<span>#</span>getBundle` referenced by `org.eclipse.equinox.internal.jsp.jasper.Activator`.

Import-Package `org.osgi.util.tracker 1.3.1` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.2` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.internal.jsp.jasper.Activator`.

Import-Package `org.osgi.util.tracker 1.3.1` (compiled against `1.5.4` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.3.3` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/util/tracker/ServiceTracker<span>#</span><init>` referenced by `org.eclipse.equinox.internal.jsp.jasper.Activator`.


Suggested lower version for package `org.osgi.framework` is `1.5.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]
Suggested lower version for package `org.osgi.util.tracker` is `1.5.0` out of [`1.3.3`, `1.4.0`, `1.4.2`, `1.5.0`, `1.5.1`, `1.5.2`, `1.5.3`, `1.5.4`]