### PR TITLE
Clean Code for bundles/org.eclipse.equinox.console

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/Activator.java
@@ -238,7 +238,7 @@ public class Activator implements BundleActivator {
 	// provided by a CommandProviderAdapter.
 	public class CommandCustomizer implements ServiceTrackerCustomizer<CommandProvider, List<ServiceRegistration<?>>> {
 
-		private BundleContext context;
+		private final BundleContext context;
 
 		public CommandCustomizer(BundleContext context) {
 			this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/CustomCommandInterpreter.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/command/adapter/CustomCommandInterpreter.java
@@ -36,10 +36,10 @@ import org.osgi.framework.Bundle;
  * the CommandProviderAdapter.
  */
 public class CustomCommandInterpreter implements CommandInterpreter {
-	private PrintStream out = System.out;
+	private final PrintStream out = System.out;
 	/** Strings used to format other strings */
-	private String tab = "\t"; //$NON-NLS-1$
-	private String newline = "\r\n"; //$NON-NLS-1$
+	private final String tab = "\t"; //$NON-NLS-1$
+	private final String newline = "\r\n"; //$NON-NLS-1$
 	private final Iterator<Object> arguments;
 	private final CommandSession commandSession;
 	/**

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/CommandsTracker.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/CommandsTracker.java
@@ -26,7 +26,7 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 public class CommandsTracker {
-	private Set<String> commandNames;
+	private final Set<String> commandNames;
 	private ServiceTracker<Object, Set<String>> commandsTracker = null;
 	private static final Object lock = new Object();
 

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/DisconnectCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/DisconnectCommand.java
@@ -34,7 +34,7 @@ public class DisconnectCommand {
 	private static final String DISCONNECT_MESSAGE = "Disconnect from console? (y/n; default=y) ";
 	private static final String DISCONNECT_CONFIRMATION_Y = "y";
 
-	private BundleContext context;
+	private final BundleContext context;
 
 	public DisconnectCommand(BundleContext context) {
 		this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/EquinoxCommandProvider.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/EquinoxCommandProvider.java
@@ -181,7 +181,7 @@ public class EquinoxCommandProvider implements SynchronousBundleListener {
 	/** this list contains the bundles known to be lazily awaiting activation */
 	private final List<Bundle> lazyActivation = new ArrayList<>();
 
-	private Activator activator;
+	private final Activator activator;
 
 	/** commands provided by this command provider */
 	private static final String[] functions = new String[] { "exit", "shutdown", "sta", "start", "sto", "stop", "i",

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ExportStateCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ExportStateCommand.java
@@ -29,7 +29,7 @@ import org.osgi.framework.BundleContext;
 
 public class ExportStateCommand {
 
-	private BundleContext context;
+	private final BundleContext context;
 
 	public ExportStateCommand(BundleContext context) {
 		this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/HelpCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/HelpCommand.java
@@ -38,14 +38,14 @@ import org.apache.felix.service.command.CommandSession;
  * to Gogo commands.
  */
 public class HelpCommand {
-	private BundleContext context;
-	private Set<CommandProvider> legacyCommandProviders;
-	private ServiceTracker<CommandProvider, Set<CommandProvider>> commandProvidersTracker;
-	private ServiceTracker<CommandsTracker, CommandsTracker> commandsTrackerTracker;
+	private final BundleContext context;
+	private final Set<CommandProvider> legacyCommandProviders;
+	private final ServiceTracker<CommandProvider, Set<CommandProvider>> commandProvidersTracker;
+	private final ServiceTracker<CommandsTracker, CommandsTracker> commandsTrackerTracker;
 	private static final String COMMANDS = ".commands";
 
 	public class CommandProviderCustomizer implements ServiceTrackerCustomizer<CommandProvider, Set<CommandProvider>> {
-		private BundleContext context;
+		private final BundleContext context;
 
 		public CommandProviderCustomizer(BundleContext context) {
 			this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ManCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/ManCommand.java
@@ -21,7 +21,7 @@ import org.apache.felix.service.command.CommandSession;
 import org.osgi.framework.BundleContext;
 
 public class ManCommand {
-	private BundleContext context;
+	private final BundleContext context;
 
 	public ManCommand(BundleContext context) {
 		this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/WireCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/commands/WireCommand.java
@@ -40,7 +40,7 @@ public class WireCommand {
 	private static final Comparator<BundleRevision> BUNDLE_REVISIONS_BY_NAME = Comparator.comparing(
 			BundleRevision::getSymbolicName, String.CASE_INSENSITIVE_ORDER);
 
-	private BundleContext context;
+	private final BundleContext context;
 
 	public WireCommand(BundleContext context) {
 		this.context = context;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/common/ConsoleInputScanner.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/common/ConsoleInputScanner.java
@@ -489,7 +489,7 @@ public class ConsoleInputScanner extends Scanner {
 	}
 
 	private static class Candidates {
-		private String[] candidates;
+		private final String[] candidates;
 		private int currentCandidateIndex = 0;
 
 		public Candidates(String[] candidates) {

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/common/ConsoleOutputStream.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/common/ConsoleOutputStream.java
@@ -37,7 +37,7 @@ public class ConsoleOutputStream extends OutputStream {
 	private boolean isEcho = true;
 	private boolean queueing = false;
 	private byte prevByte;
-	private byte[] buffer;
+	private final byte[] buffer;
 	private int pos;
 
 	/**

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/CommandNamesCompleter.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/CommandNamesCompleter.java
@@ -30,8 +30,8 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 public class CommandNamesCompleter implements Completer {
 
-	private CommandSession session;
-	private ServiceTracker<CommandsTracker, CommandsTracker> commandsTrackerTracker;
+	private final CommandSession session;
+	private final ServiceTracker<CommandsTracker, CommandsTracker> commandsTrackerTracker;
 	private static final String COMMANDS = ".commands";
 
 	public CommandNamesCompleter(BundleContext context, CommandSession session) {

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/CompletionHandler.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/CompletionHandler.java
@@ -34,8 +34,8 @@ import org.osgi.framework.ServiceReference;
  */
 public class CompletionHandler {
 
-	private BundleContext context;
-	private CommandSession session;
+	private final BundleContext context;
+	private final CommandSession session;
 	Set<Completer> completers;
 	private static final String FILE = "file";
 	private static final char VARIABLE_PREFIX = '$';

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/StringsCompleter.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/StringsCompleter.java
@@ -25,8 +25,8 @@ import org.eclipse.equinox.console.completion.common.Completer;
  */
 public class StringsCompleter implements Completer {
 
-	private Set<String> strings;
-	private boolean isCaseSensitive;
+	private final Set<String> strings;
+	private final boolean isCaseSensitive;
 
 	public StringsCompleter(Set<String> strings, boolean isCaseSensitive) {
 		this.strings = strings;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/VariableNamesCompleter.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/completion/VariableNamesCompleter.java
@@ -25,7 +25,7 @@ import org.eclipse.equinox.console.completion.common.Completer;
  */
 public class VariableNamesCompleter implements Completer {
 
-	private CommandSession session;
+	private final CommandSession session;
 
 	public VariableNamesCompleter(CommandSession session) {
 		this.session = session;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/NegotiationFinishedCallback.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/NegotiationFinishedCallback.java
@@ -24,7 +24,7 @@ package org.eclipse.equinox.console.telnet;
  */
 public class NegotiationFinishedCallback implements Callback {
 
-	private TelnetConnection telnetConnection;
+	private final TelnetConnection telnetConnection;
 
 	public NegotiationFinishedCallback(TelnetConnection telnetConnection) {
 		this.telnetConnection = telnetConnection;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetCommand.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetCommand.java
@@ -35,7 +35,7 @@ public class TelnetCommand {
 
 	private String defaultHost = null;
 	private int defaultPort;
-	private List<CommandProcessor> processors = new ArrayList<>();
+	private final List<CommandProcessor> processors = new ArrayList<>();
 	private final BundleContext context;
 	private String host = null;
 	private int port;

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetConnection.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetConnection.java
@@ -33,11 +33,11 @@ import org.osgi.framework.BundleContext;
  */
 public class TelnetConnection extends Thread implements Closeable {
 
-	private Socket socket;
-	private CommandProcessor processor;
-	private BundleContext context;
+	private final Socket socket;
+	private final CommandProcessor processor;
+	private final BundleContext context;
 	protected boolean isTelnetNegotiationFinished = false;
-	private Callback callback;
+	private final Callback callback;
 	private static final long TIMEOUT = 1000;
 	private static final long NEGOTIATION_TIMEOUT = 60000;
 	private static final String PROMPT = "prompt";

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetInputScanner.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetInputScanner.java
@@ -45,8 +45,8 @@ public class TelnetInputScanner extends Scanner {
 	private int lastRead = -1;
 	private ArrayList<Integer> currentTerminalType = new ArrayList<>();
 	private ArrayList<Integer> lastTerminalType = null;
-	private Set<String> supportedTerminalTypes = new HashSet<>();
-	private Callback callback;
+	private final Set<String> supportedTerminalTypes = new HashSet<>();
+	private final Callback callback;
 
 	public TelnetInputScanner(ConsoleInputStream toShell, ConsoleOutputStream toTelnet, Callback callback) {
 		super(toShell, toTelnet);
@@ -119,7 +119,7 @@ public class TelnetInputScanner extends Scanner {
 	private boolean isNegotiation;
 	private boolean isWill;
 
-	private byte[] tTypeRequest = { (byte) IAC, (byte) SB, (byte) TTYPE, (byte) SEND, (byte) IAC, (byte) SE };
+	private final byte[] tTypeRequest = { (byte) IAC, (byte) SB, (byte) TTYPE, (byte) SEND, (byte) IAC, (byte) SE };
 
 	private void scanCommand(final int b) throws IOException {
 		if (isNegotiation) {

--- a/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetServer.java
+++ b/bundles/org.eclipse.equinox.console/src/org/eclipse/equinox/console/telnet/TelnetServer.java
@@ -36,9 +36,9 @@ public class TelnetServer extends Thread {
 	private ServerSocket server;
 	private boolean isRunning = true;
 	private List<CommandProcessor> processors = null;
-	private BundleContext context;
-	private List<Socket> sockets = new ArrayList<>();
-	private Map<CommandProcessor, List<TelnetConnection>> processorToConnectionsMapping = new HashMap<>();
+	private final BundleContext context;
+	private final List<Socket> sockets = new ArrayList<>();
+	private final Map<CommandProcessor, List<TelnetConnection>> processorToConnectionsMapping = new HashMap<>();
 
 	public TelnetServer(BundleContext context, List<CommandProcessor> processors, String host, int port)
 			throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

