### PR TITLE
Clean Code for bundles/org.eclipse.equinox.device

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/DriverTracker.java
@@ -417,9 +417,9 @@ public class DriverTracker extends ServiceTracker {
 	}
 
 	public class DriverUpdate implements Runnable, ServiceListener, BundleListener {
-		private Activator manager_;
-		private Bundle bundle;
-		private BundleContext contxt;
+		private final Activator manager_;
+		private final Bundle bundle;
+		private final BundleContext contxt;
 
 		/** if false the thread must terminate */
 		private volatile boolean running;

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/Match.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/Match.java
@@ -20,8 +20,8 @@ import org.osgi.framework.ServiceReference;
  */
 public class Match implements org.osgi.service.device.Match {
 
-	private ServiceReference driver;
-	private int matchValue;
+	private final ServiceReference driver;
+	private final int matchValue;
 
 	Match(ServiceReference driver, int matchValue) {
 		this.driver = driver;

--- a/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/SecureAction.java
+++ b/bundles/org.eclipse.equinox.device/src/org/eclipse/equinox/device/SecureAction.java
@@ -21,7 +21,7 @@ import java.security.*;
  */
 public class SecureAction {
 	// make sure we use the correct controlContext;
-	private AccessControlContext controlContext;
+	private final AccessControlContext controlContext;
 
 	/**
 	 * Constructs a new SecureAction object. The constructed SecureAction object

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

