### PR TITLE
Clean Code for bundles/org.eclipse.equinox.event

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/mapper/BundleEventAdapter.java
+++ b/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/mapper/BundleEventAdapter.java
@@ -33,7 +33,7 @@ public class BundleEventAdapter extends EventAdapter {
 	public static final String UNINSTALLED = "UNINSTALLED"; //$NON-NLS-1$
 	public static final String RESOLVED = "RESOLVED"; //$NON-NLS-1$
 	public static final String UNRESOLVED = "UNRESOLVED"; //$NON-NLS-1$
-	private BundleEvent event;
+	private final BundleEvent event;
 
 	public BundleEventAdapter(BundleEvent event, EventAdmin eventAdmin) {
 		super(eventAdmin);

--- a/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/mapper/ServiceEventAdapter.java
+++ b/bundles/org.eclipse.equinox.event/src/org/eclipse/equinox/internal/event/mapper/ServiceEventAdapter.java
@@ -30,7 +30,7 @@ public class ServiceEventAdapter extends EventAdapter {
 	public static final String UNREGISTERING = "UNREGISTERING"; //$NON-NLS-1$
 	public static final String MODIFIED = "MODIFIED"; //$NON-NLS-1$
 	public static final String REGISTERED = "REGISTERED"; //$NON-NLS-1$
-	private ServiceEvent event;
+	private final ServiceEvent event;
 
 	public ServiceEventAdapter(ServiceEvent event, EventAdmin eventAdmin) {
 		super(eventAdmin);

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

