### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.registry

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/DefaultRegistryHttpContext.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/DefaultRegistryHttpContext.java
@@ -22,7 +22,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.service.http.HttpContext;
 
 public class DefaultRegistryHttpContext implements HttpContext {
-	private HttpContext delegate;
+	private final HttpContext delegate;
 	private List<ResourceMapping> resourceMappings;
 	private Properties mimeMappings;
 
@@ -93,8 +93,8 @@ public class DefaultRegistryHttpContext implements HttpContext {
 	}
 
 	public static class ResourceMapping {
-		private Bundle bundle;
-		private String bundlePath;
+		private final Bundle bundle;
+		private final String bundlePath;
 
 		public ResourceMapping(Bundle bundle, String path) {
 			this.bundle = bundle;

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/FilterManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/FilterManager.java
@@ -46,13 +46,13 @@ public class FilterManager implements ExtensionPointTracker.Listener {
 
 	private static final String FILTER = "filter"; //$NON-NLS-1$
 
-	private ExtensionPointTracker tracker;
+	private final ExtensionPointTracker tracker;
 
-	private HttpRegistryManager httpRegistryManager;
+	private final HttpRegistryManager httpRegistryManager;
 
-	private Map<IConfigurationElement, Filter> registered = new HashMap<>();
+	private final Map<IConfigurationElement, Filter> registered = new HashMap<>();
 
-	private ServiceReference<?> reference;
+	private final ServiceReference<?> reference;
 
 	public FilterManager(HttpRegistryManager httpRegistryManager, ServiceReference<?> reference,
 			IExtensionRegistry registry) {
@@ -154,7 +154,7 @@ public class FilterManager implements ExtensionPointTracker.Listener {
 
 	private static class FilterWrapper implements Filter {
 
-		private IConfigurationElement element;
+		private final IConfigurationElement element;
 		private Filter delegate;
 		private FilterConfig config;
 		private boolean loadOnStartup = false;

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpContextManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpContextManager.java
@@ -37,9 +37,9 @@ public class HttpContextManager implements Listener {
 	private static final String RESOURCEMAPPING = "resource-mapping"; //$NON-NLS-1$
 	private static final String BUNDLE = "bundle"; //$NON-NLS-1$
 
-	private List<IConfigurationElement> registered = new ArrayList<>();
-	private HttpRegistryManager httpRegistryManager;
-	private ExtensionPointTracker tracker;
+	private final List<IConfigurationElement> registered = new ArrayList<>();
+	private final HttpRegistryManager httpRegistryManager;
+	private final ExtensionPointTracker tracker;
 
 	public HttpContextManager(HttpRegistryManager httpRegistryManager, IExtensionRegistry registry) {
 		this.httpRegistryManager = httpRegistryManager;

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpRegistryManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpRegistryManager.java
@@ -83,17 +83,17 @@ public class HttpRegistryManager {
 		}
 	}
 
-	private HttpContextManager httpContextManager;
-	private ServletManager servletManager;
-	private FilterManager filterManager;
-	private ResourceManager resourceManager;
-	private HttpService httpService;
-	private PackageAdmin packageAdmin;
-	private Map<String, HttpContextContribution> contexts = new HashMap<>();
-	private Map<String, FilterContribution> filters = new HashMap<>();
-	private Map<String, ServletContribution> servlets = new HashMap<>();
-	private Map<String, ResourcesContribution> resources = new HashMap<>();
-	private Set<String> registered = new HashSet<>();
+	private final HttpContextManager httpContextManager;
+	private final ServletManager servletManager;
+	private final FilterManager filterManager;
+	private final ResourceManager resourceManager;
+	private final HttpService httpService;
+	private final PackageAdmin packageAdmin;
+	private final Map<String, HttpContextContribution> contexts = new HashMap<>();
+	private final Map<String, FilterContribution> filters = new HashMap<>();
+	private final Map<String, ServletContribution> servlets = new HashMap<>();
+	private final Map<String, ResourcesContribution> resources = new HashMap<>();
+	private final Set<String> registered = new HashSet<>();
 
 	public HttpRegistryManager(ServiceReference<?> reference, HttpService httpService, PackageAdmin packageAdmin,
 			IExtensionRegistry registry) {

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpServiceTracker.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/HttpServiceTracker.java
@@ -27,8 +27,8 @@ import org.osgi.util.tracker.ServiceTracker;
 
 public class HttpServiceTracker extends ServiceTracker<HttpService, HttpService> {
 
-	private PackageAdmin packageAdmin;
-	private IExtensionRegistry registry;
+	private final PackageAdmin packageAdmin;
+	private final IExtensionRegistry registry;
 
 	private ServiceRegistration<?> registration;
 	Map<ServiceReference<HttpService>, HttpRegistryManager> httpRegistryManagers = new HashMap<>();
@@ -98,7 +98,7 @@ public class HttpServiceTracker extends ServiceTracker<HttpService, HttpService>
 
 	public class HttpContextExtensionServiceImpl implements HttpContextExtensionService {
 
-		private Bundle bundle;
+		private final Bundle bundle;
 
 		public HttpContextExtensionServiceImpl(Bundle bundle) {
 			this.bundle = bundle;

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/ResourceManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/ResourceManager.java
@@ -40,13 +40,13 @@ public class ResourceManager implements ExtensionPointTracker.Listener {
 
 	private static final String FILTER = "filter"; //$NON-NLS-1$
 
-	private ExtensionPointTracker tracker;
+	private final ExtensionPointTracker tracker;
 
-	private List<IConfigurationElement> registered = new ArrayList<>();
+	private final List<IConfigurationElement> registered = new ArrayList<>();
 
-	private HttpRegistryManager httpRegistryManager;
+	private final HttpRegistryManager httpRegistryManager;
 
-	private ServiceReference<?> reference;
+	private final ServiceReference<?> reference;
 
 	public ResourceManager(HttpRegistryManager httpRegistryManager, ServiceReference<?> reference,
 			IExtensionRegistry registry) {

--- a/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/ServletManager.java
+++ b/bundles/org.eclipse.equinox.http.registry/src/org/eclipse/equinox/http/registry/internal/ServletManager.java
@@ -47,13 +47,13 @@ public class ServletManager implements ExtensionPointTracker.Listener {
 
 	private static final String FILTER = "filter"; //$NON-NLS-1$
 
-	private ExtensionPointTracker tracker;
+	private final ExtensionPointTracker tracker;
 
-	private HttpRegistryManager httpRegistryManager;
+	private final HttpRegistryManager httpRegistryManager;
 
-	private List<IConfigurationElement> registered = new ArrayList<>();
+	private final List<IConfigurationElement> registered = new ArrayList<>();
 
-	private ServiceReference<?> reference;
+	private final ServiceReference<?> reference;
 
 	public ServletManager(HttpRegistryManager httpRegistryManager, ServiceReference<?> reference,
 			IExtensionRegistry registry) {
@@ -155,7 +155,7 @@ public class ServletManager implements ExtensionPointTracker.Listener {
 	}
 
 	private static class ServletWrapper implements Servlet {
-		private IConfigurationElement element;
+		private final IConfigurationElement element;
 		private Servlet delegate;
 		private ServletConfig config;
 		private boolean loadOnStartup = false;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

