### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.servlet.tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestFilter1.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestFilter1.java
@@ -53,5 +53,5 @@ public class TestFilter1 extends AbstractTestServlet {
 		writer.print('a');
 	}
 
-	private Filter f1 = new BaseFilter('b');
+	private final Filter f1 = new BaseFilter('b');
 }

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestResource2.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestResource2.java
@@ -48,8 +48,8 @@ public class TestResource2 extends AbstractTestResource {
 		service.unregisterFilter(f3);
 	}
 
-	private Filter f1 = new BaseFilter('c');
-	private Filter f2 = new BaseFilter('b');
-	private Filter f3 = new BaseFilter('d');
+	private final Filter f1 = new BaseFilter('c');
+	private final Filter f2 = new BaseFilter('b');
+	private final Filter f3 = new BaseFilter('d');
 
 }

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestResource4.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestResource4.java
@@ -50,8 +50,8 @@ public class TestResource4 extends AbstractTestResource {
 		service.unregisterFilter(f3);
 	}
 
-	private Filter f1 = new BaseFilter('c');
-	private Filter f2 = new BaseFilter('b');
-	private Filter f3 = new BaseFilter('d');
+	private final Filter f1 = new BaseFilter('c');
+	private final Filter f2 = new BaseFilter('b');
+	private final Filter f3 = new BaseFilter('d');
 
 }

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServletContextHelper10.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/tb1/TestServletContextHelper10.java
@@ -80,5 +80,5 @@ public class TestServletContextHelper10 extends AbstractTestServlet {
 		writer.print('a');
 	}
 
-	private Filter f1 = new BaseFilter('c');
+	private final Filter f1 = new BaseFilter('c');
 }

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/util/BaseFilter.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/util/BaseFilter.java
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class BaseFilter implements Filter {
 
-	private char c;
+	private final char c;
 
 	public BaseFilter(char c) {
 		this.c = c;

--- a/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/util/CharResponseWrapper.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/bundles_src/tb1/org/eclipse/equinox/http/servlet/tests/util/CharResponseWrapper.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
  * @author Raymond Augé
  */
 public class CharResponseWrapper extends HttpServletResponseWrapper {
-	private CharArrayWriter output;
+	private final CharArrayWriter output;
 
 	public CharResponseWrapper(HttpServletResponse response) {
 		super(response);

--- a/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/bundle/BundleInstaller.java
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/src/org/eclipse/equinox/http/servlet/tests/bundle/BundleInstaller.java
@@ -28,10 +28,10 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.util.tracker.ServiceTracker;
 
 public class BundleInstaller {
-	private BundleContext context;
-	private String rootLocation;
+	private final BundleContext context;
+	private final String rootLocation;
 	private HashMap<String, Bundle> bundles = new HashMap<>();
-	private ServiceTracker<Object, Object> converter;
+	private final ServiceTracker<Object, Object> converter;
 
 	public BundleInstaller(String bundlesRoot, BundleContext context) throws InvalidSyntaxException {
 		this.context = context;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

