### PR TITLE
Clean Code for bundles/org.eclipse.equinox.preferences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/OSGiPreferencesServiceImpl.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/internal/preferences/OSGiPreferencesServiceImpl.java
@@ -38,10 +38,10 @@ public class OSGiPreferencesServiceImpl implements PreferencesService {
 	private static final class OSGiLocalRootPreferences implements Preferences {
 
 		// The "local" root of this preference tree (not the real Eclipse root)
-		private Preferences root;
+		private final Preferences root;
 
 		// the node this node is wrappering
-		private Preferences wrapped;
+		private final Preferences wrapped;
 
 		private OSGiLocalRootPreferences(Preferences root) {
 			this(root, root);
@@ -252,7 +252,7 @@ public class OSGiPreferencesServiceImpl implements PreferencesService {
 
 	} // end static inner class OSGiLocalRootPreferences
 
-	private IEclipsePreferences bundlePreferences;
+	private final IEclipsePreferences bundlePreferences;
 
 	OSGiPreferencesServiceImpl(IEclipsePreferences bundlePreferences) {
 		this.bundlePreferences = bundlePreferences;

--- a/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/IEclipsePreferences.java
+++ b/bundles/org.eclipse.equinox.preferences/src/org/eclipse/core/runtime/preferences/IEclipsePreferences.java
@@ -42,7 +42,7 @@ public interface IEclipsePreferences extends Preferences {
 		 */
 		private static final long serialVersionUID = 1L;
 
-		private Preferences child;
+		private final Preferences child;
 
 		/**
 		 * Constructor for a new node change event object.
@@ -127,9 +127,9 @@ public interface IEclipsePreferences extends Preferences {
 		 */
 		private static final long serialVersionUID = 1L;
 
-		private String key;
-		private Object newValue;
-		private Object oldValue;
+		private final String key;
+		private final Object newValue;
+		private final Object oldValue;
 
 		/**
 		 * Constructor for a new preference change event. The node and the key must not

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

