### PR TITLE
Clean Code for bundles/org.eclipse.equinox.region

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionDigraph.java
+++ b/bundles/org.eclipse.equinox.region/src/org/eclipse/equinox/internal/region/StandardRegionDigraph.java
@@ -253,9 +253,9 @@ public final class StandardRegionDigraph implements BundleIdToRegionMapping, Reg
 
 	static class StandardFilteredRegion implements FilteredRegion {
 
-		private Region region;
+		private final Region region;
 
-		private RegionFilter regionFilter;
+		private final RegionFilter regionFilter;
 
 		StandardFilteredRegion(Region region, RegionFilter regionFilter) {
 			this.region = region;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

