### PR TITLE
Clean Code for bundles/org.eclipse.equinox.registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/BufferedRandomInputStream.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/BufferedRandomInputStream.java
@@ -21,7 +21,7 @@ import java.io.*;
 public class BufferedRandomInputStream extends InputStream {
 
 	private RandomAccessFile inputFile;
-	private String filePath; // Canonical path to the underlying file used for logging
+	private final String filePath; // Canonical path to the underlying file used for logging
 	private int buffer_size; // Current size of the buffer
 	private int buffer_pos; // Current read position in the buffer
 	/**

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Handle.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Handle.java
@@ -26,7 +26,7 @@ import org.eclipse.core.runtime.InvalidRegistryObjectException;
 public abstract class Handle {
 	protected IObjectManager objectManager;
 
-	private int objectId;
+	private final int objectId;
 
 	public int getId() {
 		return objectId;

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/osgi/Activator.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/osgi/Activator.java
@@ -40,7 +40,7 @@ public class Activator implements BundleActivator {
 	 */
 	private static final String STORAGE_DIR = "org.eclipse.core.runtime"; //$NON-NLS-1$
 
-	private Object masterRegistryKey = new Object();
+	private final Object masterRegistryKey = new Object();
 	private Object userRegistryKey = new Object();
 
 	private IExtensionRegistry defaultRegistry = null;

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementAttribute.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementAttribute.java
@@ -39,14 +39,14 @@ public final class ConfigurationElementAttribute {
 	 * 
 	 * @see IConfigurationElement#getAttributeNames()
 	 */
-	private String name;
+	private final String name;
 
 	/**
 	 * Attribute value.
 	 * 
 	 * @see IConfigurationElement#getAttributeAsIs(String)
 	 */
-	private String value;
+	private final String value;
 
 	/**
 	 * Constructor.

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementDescription.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementDescription.java
@@ -41,28 +41,28 @@ public final class ConfigurationElementDescription {
 	 * 
 	 * @see IConfigurationElement#getName()
 	 */
-	private String name;
+	private final String name;
 
 	/**
 	 * Attributes of the configuration element.
 	 * 
 	 * @see IConfigurationElement#getAttribute(String)
 	 */
-	private ConfigurationElementAttribute[] attributes;
+	private final ConfigurationElementAttribute[] attributes;
 
 	/**
 	 * String value to be stored in this configuration element.
 	 * 
 	 * @see IConfigurationElement#getValue()
 	 */
-	private String value;
+	private final String value;
 
 	/**
 	 * Children of the configuration element.
 	 * 
 	 * @see IConfigurationElement#getChildren()
 	 */
-	private ConfigurationElementDescription[] children;
+	private final ConfigurationElementDescription[] children;
 
 	/**
 	 * Constructor.

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryContributor.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryContributor.java
@@ -40,12 +40,12 @@ public final class RegistryContributor implements IContributor {
 	 * Actual ID of the contributor (e.g., "12"). IDs are expected to be unique in
 	 * the workspace.
 	 */
-	private String actualContributorId;
+	private final String actualContributorId;
 
 	/**
 	 * Actual name of the contributor (e.g., "org.eclipse.core.runtime.fragment").
 	 */
-	private String actualContributorName;
+	private final String actualContributorName;
 
 	/**
 	 * ID associated with the entity "in charge" of the contributor (e.g., "1"). IDs

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

