### PR TITLE
Clean Code for bundles/org.eclipse.equinox.security.ui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/provisional/security/ui/X509CertificateViewDialog.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/provisional/security/ui/X509CertificateViewDialog.java
@@ -28,9 +28,9 @@ import org.eclipse.swt.layout.*;
 import org.eclipse.swt.widgets.*;
 
 public class X509CertificateViewDialog extends TitleAreaDialog {
-	private X509Certificate theCert;
+	private final X509Certificate theCert;
 	private static final DateFormat _df = DateFormat.getDateInstance(DateFormat.LONG);
-	private X500PrincipalHelper nameHelper = new X500PrincipalHelper();
+	private final X500PrincipalHelper nameHelper = new X500PrincipalHelper();
 
 	// We use the "bannerFont" for our bold font
 	private static Font boldFont = JFaceResources.getBannerFont();

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/ConfirmationDialog.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/ConfirmationDialog.java
@@ -26,7 +26,7 @@ public class ConfirmationDialog extends TitleAreaDialog {
 	public static final int YES = 100;
 	public static final int NO = 101;
 
-	private Certificate cert;
+	private final Certificate cert;
 
 	public ConfirmationDialog(Shell parentShell, Certificate cert) {
 		super(parentShell);

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/DefaultAuthorizationManager.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/DefaultAuthorizationManager.java
@@ -27,7 +27,7 @@ public class DefaultAuthorizationManager extends AuthorizationManager {
 	boolean enabled = (null != Activator.getAuthorizationEngine());
 
 	private int currentStatus = IStatus.OK;
-	private boolean needsAttention = false;
+	private final boolean needsAttention = false;
 
 	public DefaultAuthorizationManager() {
 		currentStatus = enabled ? Activator.getAuthorizationEngine().getStatus() : IStatus.OK;

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/SecurityStatusControl.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/SecurityStatusControl.java
@@ -45,7 +45,7 @@ public class SecurityStatusControl extends ControlContribution {
 	/* the default id for this Item */
 	private static final String ID = "org.eclipse.ui.securityStatus"; //$NON-NLS-1$
 
-	private IWorkbenchWindow window;
+	private final IWorkbenchWindow window;
 	private CLabel label;
 
 	private IconState currentState;

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/X509CertificateAttribute.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/X509CertificateAttribute.java
@@ -23,16 +23,16 @@ public class X509CertificateAttribute {
 	// Description of the field
 	// NOTE: This will show in the UI so it should be loaded from a translatable
 	// properties file.
-	private String fieldDescription;
+	private final String fieldDescription;
 
 	// A String representation of the value of the field. May have undergone some
 	// transformation to make it "pretty" in the UI
-	private String stringVal;
+	private final String stringVal;
 
 	// The raw data object from inside the certificate. Most likely whatever object
 	// the getter method
 	// for the field returns.
-	private Object rawValue;
+	private final Object rawValue;
 
 	public X509CertificateAttribute(String propDescription, String StringVal, Object objValue) {
 		super();

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/X509CertificateAttributeContentProvider.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/X509CertificateAttributeContentProvider.java
@@ -47,7 +47,7 @@ public class X509CertificateAttributeContentProvider implements IStructuredConte
 	private static String LABEL_KEYUSAGE_ENCIPHERONLY = "encipherOnly"; //$NON-NLS-1$
 	private static String LABEL_KEYUSAGE_DECIPHERONLY = "decipherOnly"; //$NON-NLS-1$
 
-	private ArrayList<X509CertificateAttribute> elements = new ArrayList<>();
+	private final ArrayList<X509CertificateAttribute> elements = new ArrayList<>();
 	private Viewer viewer = null;
 	private static String listDelim = ", "; //$NON-NLS-1$
 

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/UICallbackProvider.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/UICallbackProvider.java
@@ -35,7 +35,7 @@ public class UICallbackProvider implements IUICallbacks {
 
 	private static class InitWithProgress implements IRunnableWithProgress {
 
-		private IStorageTask callback;
+		private final IStorageTask callback;
 		private StorageException exception = null;
 
 		public InitWithProgress(IStorageTask callback) {

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/view/ValuesView.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/storage/view/ValuesView.java
@@ -58,9 +58,9 @@ public class ValuesView {
 	protected Shell shell;
 
 	class TableValuesElement {
-		private String key;
+		private final String key;
 		private String value;
-		private boolean encrypted;
+		private final boolean encrypted;
 
 		public TableValuesElement(String key) {
 			this.key = key;

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportTrustEngineSelectPage.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateImportTrustEngineSelectPage.java
@@ -27,7 +27,7 @@ public class CertificateImportTrustEngineSelectPage extends WizardPage implement
 
 	private Text aliasField;
 	private Combo trustEngineCombo;
-	private ArrayList<TrustEngine> trustEngines = new ArrayList<>();
+	private final ArrayList<TrustEngine> trustEngines = new ArrayList<>();
 
 	protected CertificateImportTrustEngineSelectPage(String pageName) {
 		super(pageName);

--- a/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateViewer.java
+++ b/bundles/org.eclipse.equinox.security.ui/src/org/eclipse/equinox/internal/security/ui/wizard/CertificateViewer.java
@@ -23,9 +23,9 @@ import org.eclipse.swt.widgets.*;
 
 public class CertificateViewer {
 
-	private Composite composite;
+	private final Composite composite;
 
-	private TableViewer tableViewer;
+	private final TableViewer tableViewer;
 
 	public CertificateViewer(Composite parent) {
 		composite = new Composite(parent, SWT.None);

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

