### PR TITLE
Clean Code for bundles/org.eclipse.equinox.security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/ConfigurationFederator.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/ConfigurationFederator.java
@@ -29,8 +29,8 @@ public class ConfigurationFederator extends Configuration {
 	// events
 	private Configuration[] federatedConfigs = null;
 
-	private Hashtable<String, AppConfigurationEntry[]> configCache = new Hashtable<>(5);
-	private Hashtable<String, String> configToProviderMap = new Hashtable<>(5);
+	private final Hashtable<String, AppConfigurationEntry[]> configCache = new Hashtable<>(5);
+	private final Hashtable<String, String> configToProviderMap = new Hashtable<>(5);
 
 	final private Configuration defaultConfiguration;
 

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/SecureContext.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/SecureContext.java
@@ -25,11 +25,11 @@ import org.eclipse.equinox.security.auth.ILoginContextListener;
 
 public class SecureContext implements ILoginContext {
 
-	private String configName;
+	private final String configName;
 	private LoginContext loginContext;
-	private CallbackHandler handler;
+	private final CallbackHandler handler;
 
-	private SecurityEventsManager eventsManager = new SecurityEventsManager();
+	private final SecurityEventsManager eventsManager = new SecurityEventsManager();
 	private boolean loggedIn = false;
 
 	public SecureContext(String configugationName) {

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/SecurePlatformInternal.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/SecurePlatformInternal.java
@@ -32,7 +32,7 @@ public class SecurePlatformInternal {
 	private static final String PROVIDER_URL_BASE = "login.config.url.";//$NON-NLS-1$
 	private static final int MAX_PROVIDER_URL_COUNT = 777; // arbitrary upper limit on the number of provider URLs
 	private Configuration defaultConfiguration;
-	private ExtCallbackHandlerLoader callbackHandlerLoader = new ExtCallbackHandlerLoader();
+	private final ExtCallbackHandlerLoader callbackHandlerLoader = new ExtCallbackHandlerLoader();
 
 	private boolean running = false;
 	private static final SecurePlatformInternal s_instance = new SecurePlatformInternal();

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/events/SecurityEventsManager.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/auth/events/SecurityEventsManager.java
@@ -20,7 +20,7 @@ import org.eclipse.equinox.security.auth.ILoginContextListener;
 
 public class SecurityEventsManager {
 
-	private Vector<ILoginContextListener> listeners = new Vector<>(5);
+	private final Vector<ILoginContextListener> listeners = new Vector<>(5);
 
 	synchronized public void addListener(ILoginContextListener listener) {
 		listeners.add(listener);

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/PasswordProviderSelector.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/PasswordProviderSelector.java
@@ -43,7 +43,7 @@ public class PasswordProviderSelector implements IRegistryEventListener {
 	final private static String HINTS_NAME = "hint";//$NON-NLS-1$
 	final private static String HINT_VALUE = "value";//$NON-NLS-1$
 
-	private Map<String, PasswordProviderModuleExt> modules = new HashMap<>(5); // cache of modules found
+	private final Map<String, PasswordProviderModuleExt> modules = new HashMap<>(5); // cache of modules found
 
 	public class ExtStorageModule {
 		public String moduleID;

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesContainer.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesContainer.java
@@ -74,7 +74,7 @@ import org.eclipse.equinox.security.storage.provider.IPreferencesContainer;
  */
 public class SecurePreferencesContainer implements IPreferencesContainer {
 
-	private Map<SecurePreferences, SecurePreferencesWrapper> wrappers = new HashMap<>(); // node ->
+	private final Map<SecurePreferences, SecurePreferencesWrapper> wrappers = new HashMap<>(); // node ->
 																							// SecurePreferencesWrapper
 
 	final private Map<Object, Object> options;

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/SecurePreferencesRoot.java
@@ -77,9 +77,9 @@ public class SecurePreferencesRoot extends SecurePreferences implements IStorage
 
 	private boolean modified = false;
 
-	private JavaEncryption cipher = new JavaEncryption();
+	private final JavaEncryption cipher = new JavaEncryption();
 
-	private Map<String, PasswordExt> passwordCache = new HashMap<>(5); // cached passwords: module ID -> PasswordExt
+	private final Map<String, PasswordExt> passwordCache = new HashMap<>(5); // cached passwords: module ID -> PasswordExt
 
 	public SecurePreferencesRoot(URL location) throws IOException {
 		super(null, null);

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/PasswordProviderDescription.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/PasswordProviderDescription.java
@@ -22,11 +22,11 @@ public class PasswordProviderDescription {
 
 	static final private String EMPTY_STRING = ""; //$NON-NLS-1$
 
-	private int priority;
-	private String id;
-	private String name;
-	private String description;
-	private List<String> hints;
+	private final int priority;
+	private final String id;
+	private final String name;
+	private final String description;
+	private final List<String> hints;
 
 	public PasswordProviderDescription(String name, String id, int priority, String description, List<String> hints) {
 		this.id = id;

--- a/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/ReEncrypter.java
+++ b/bundles/org.eclipse.equinox.security/src/org/eclipse/equinox/internal/security/storage/friends/ReEncrypter.java
@@ -32,8 +32,8 @@ import org.eclipse.osgi.util.NLS;
 public class ReEncrypter {
 
 	private static class TmpElement {
-		private String path; // absolute node path
-		private Map<String, String> values; // <String>key -> <String>value
+		private final String path; // absolute node path
+		private final Map<String, String> values; // <String>key -> <String>value
 
 		public TmpElement(String path, Map<String, String> values) {
 			this.path = path;
@@ -53,7 +53,7 @@ public class ReEncrypter {
 	final private String moduleID;
 	private boolean processedOK = true;
 
-	private ArrayList<TmpElement> elements = new ArrayList<>(); // List<TmpElement>
+	private final ArrayList<TmpElement> elements = new ArrayList<>(); // List<TmpElement>
 
 	public ReEncrypter(ISecurePreferences prefs, String moduleID) {
 		this.moduleID = moduleID;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

