### PR TITLE
Clean Code for bundles/org.eclipse.equinox.transforms.hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/LazyInputStream.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/LazyInputStream.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
  */
 public class LazyInputStream extends InputStream {
 
-	private InputStreamProvider provider;
+	private final InputStreamProvider provider;
 
 	private InputStream original = null;
 

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ProxyStreamTransformer.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ProxyStreamTransformer.java
@@ -30,8 +30,8 @@ import java.net.URL;
  */
 public class ProxyStreamTransformer extends StreamTransformer {
 
-	private Method method;
-	private Object object;
+	private final Method method;
+	private final Object object;
 
 	/**
 	 * Create a new proxy transformer based on the given object.

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ReplaceTransformer.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/ReplaceTransformer.java
@@ -28,7 +28,7 @@ import org.osgi.framework.FrameworkUtil;
 class ReplaceTransformer {
 
 	static final String TYPE = "replace"; //$NON-NLS-1$
-	private TransformerHook hook;
+	private final TransformerHook hook;
 
 	ReplaceTransformer(TransformerHook hook) {
 		this.hook = hook;

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformInstanceListData.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformInstanceListData.java
@@ -39,18 +39,18 @@ public class TransformInstanceListData extends ServiceTracker<URL, URL> {
 	/**
 	 * Map from transformer class -> tuple array
 	 */
-	private Map<String, TransformTuple[]> transformerToTuple = new HashMap<>();
+	private final Map<String, TransformTuple[]> transformerToTuple = new HashMap<>();
 
 	/**
 	 * List of all tuples in the system.
 	 */
-	private List<TransformTuple> rawTuples = new ArrayList<>();
+	private final List<TransformTuple> rawTuples = new ArrayList<>();
 
 	/**
 	 * Map from bundle ID -> boolean representing whether or not a given bundle
 	 * currently has any transforms registered against it.
 	 */
-	private Map<String, Boolean> bundleIdToTransformPresence = new HashMap<>();
+	private final Map<String, Boolean> bundleIdToTransformPresence = new HashMap<>();
 	private final EquinoxLogServices logServices;
 
 	/**

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformedBundleEntry.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformedBundleEntry.java
@@ -29,8 +29,8 @@ public class TransformedBundleEntry extends BundleEntry {
 
 	long timestamp;
 	private InputStream stream;
-	private BundleEntry original;
-	private TransformedBundleFile bundleFile;
+	private final BundleEntry original;
+	private final TransformedBundleFile bundleFile;
 
 	/**
 	 * Create a wrapped bundle entry. Calls to obtain the content of this entry will

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerBundleExtender.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerBundleExtender.java
@@ -30,7 +30,7 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
 class TransformerBundleExtender implements BundleTrackerCustomizer<ServiceRegistration<URL>> {
 
 	private static final String EQUINOX_TRANSFORMER_HEADER = "Equinox-Transformer"; //$NON-NLS-1$
-	private BundleContext bundleContext;
+	private final BundleContext bundleContext;
 
 	public TransformerBundleExtender(BundleContext bundleContext) {
 		this.bundleContext = bundleContext;

--- a/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerList.java
+++ b/bundles/org.eclipse.equinox.transforms.hook/src/org/eclipse/equinox/internal/transforms/TransformerList.java
@@ -35,7 +35,7 @@ public class TransformerList extends ServiceTracker<Object, Object> {
 	/**
 	 * Local cache of transformers.
 	 */
-	private HashMap<String, StreamTransformer> transformers = new HashMap<>();
+	private final HashMap<String, StreamTransformer> transformers = new HashMap<>();
 	private final EquinoxLogServices logServices;
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

