### PR TITLE
Clean Code for bundles/org.eclipse.osgi.compatibility.state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/PlatformBundleListener.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/compatibility/state/PlatformBundleListener.java
@@ -33,7 +33,7 @@ class PlatformBundleListener implements SynchronousBundleListener, FrameworkList
 	private final ModuleDatabase database;
 	private final ModuleContainer container;
 	private long lastResolveStamp = -1;
-	private AtomicBoolean gotUnresolved = new AtomicBoolean(false);
+	private final AtomicBoolean gotUnresolved = new AtomicBoolean(false);
 
 	PlatformBundleListener(State systemState, StateConverter converter, ModuleDatabase database, ModuleContainer container) {
 		this.systemState = systemState;

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/GroupingChecker.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/GroupingChecker.java
@@ -27,7 +27,7 @@ public class GroupingChecker {
 	// a mapping of bundles to their package roots; keyed by
 	// ResolverBundle -> HashMap of packages; keyed by
 	// package name -> PackageRoots
-	private Map<ResolverBundle, Map<String, PackageRoots>> bundles = new HashMap<>();
+	private final Map<ResolverBundle, Map<String, PackageRoots>> bundles = new HashMap<>();
 
 	/*
 	 * This method fully populates a bundles package roots for the purpose of resolving
@@ -284,7 +284,7 @@ public class GroupingChecker {
 	}
 
 	class PackageRoots {
-		private String name;
+		private final String name;
 		private ResolverExport[] roots;
 
 		PackageRoots(String name) {

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/PermissionChecker.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/PermissionChecker.java
@@ -19,7 +19,7 @@ import org.osgi.framework.*;
 
 public class PermissionChecker {
 	private boolean checkPermissions = false;
-	private ResolverImpl resolver;
+	private final ResolverImpl resolver;
 
 	public PermissionChecker(boolean checkPermissions, ResolverImpl resolver) {
 		this.checkPermissions = checkPermissions;

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/ResolverExport.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/ResolverExport.java
@@ -21,7 +21,7 @@ import org.osgi.framework.Constants;
  * A companion to ExportPackageDescription from the state used while resolving.
  */
 public class ResolverExport extends VersionSupplier {
-	private ResolverBundle resolverBundle;
+	private final ResolverBundle resolverBundle;
 
 	ResolverExport(ResolverBundle resolverBundle, ExportPackageDescription epd) {
 		super(epd);

--- a/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/ResolverImpl.java
+++ b/bundles/org.eclipse.osgi.compatibility.state/src/org/eclipse/osgi/internal/module/ResolverImpl.java
@@ -91,7 +91,7 @@ public class ResolverImpl implements Resolver {
 	// Used to check permissions for import/export, provide/require, host/fragment
 	private final PermissionChecker permissionChecker;
 	// Set of bundles that are pending removal
-	private MappedList<Long, BundleDescription> removalPending = new MappedList<>();
+	private final MappedList<Long, BundleDescription> removalPending = new MappedList<>();
 	// Indicates whether this resolver has been initialized
 	private boolean initialized = false;
 

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

