### PR TITLE
Clean Code for bundles/org.eclipse.osgi.tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,8 +6,7 @@ concurrency:
     cancel-in-progress: true
 
 on:
-  pull_request:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   check-freeze-period:

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/TestListener.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/TestListener.java
@@ -19,7 +19,7 @@ import org.osgi.service.log.LogListener;
 
 public class TestListener implements LogListener {
 	private final String testBundleLoc;
-	private LinkedList<LogEntry> logs = new LinkedList<>();
+	private final LinkedList<LogEntry> logs = new LinkedList<>();
 
 	public TestListener() {
 		this(null);

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/TestListener2.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/equinox/log/test/TestListener2.java
@@ -21,8 +21,8 @@ import org.osgi.service.log.LogEntry;
 import org.osgi.service.log.LogListener;
 
 public class TestListener2 implements LogListener {
-	private List<String> list;
-	private AtomicInteger flag = new AtomicInteger(0);
+	private final List<String> list;
+	private final AtomicInteger flag = new AtomicInteger(0);
 	CountDownLatch latch;
 
 	public TestListener2(CountDownLatch countDownLatch) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/appadmin/ApplicationAdminTest.java
@@ -1204,8 +1204,8 @@ public class ApplicationAdminTest extends TestCase {
 	}
 
 	public static class ApplicationHandleTracker implements ServiceTrackerCustomizer {
-		private ArrayList events = new ArrayList();
-		private BundleContext bc;
+		private final ArrayList events = new ArrayList();
+		private final BundleContext bc;
 
 		public ApplicationHandleTracker(BundleContext bc) {
 			this.bc = bc;
@@ -1285,8 +1285,8 @@ public class ApplicationAdminTest extends TestCase {
 	}
 
 	public static class ApplicationDescriptorTracker implements ServiceTrackerCustomizer {
-		private BundleContext bc;
-		private ArrayList events = new ArrayList();
+		private final BundleContext bc;
+		private final ArrayList events = new ArrayList();
 
 		public ApplicationDescriptorTracker(BundleContext bc) {
 			this.bc = bc;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleInstaller.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/bundles/BundleInstaller.java
@@ -44,13 +44,13 @@ import org.osgi.util.tracker.ServiceTracker;
 
 @SuppressWarnings({ "deprecation", "removal" }) // AccessController
 public class BundleInstaller {
-	private BundleContext context;
-	private String rootLocation;
+	private final BundleContext context;
+	private final String rootLocation;
 	private Map<String, Bundle> bundles = new HashMap<>();
-	private ServiceTracker<?, PackageAdmin> packageAdmin;
-	private ServiceTracker<?, StartLevel> startlevel;
-	private ServiceTracker<?, URLConverter> converter;
-	private ServiceTracker<?, PlatformAdmin> platformAdmin;
+	private final ServiceTracker<?, PackageAdmin> packageAdmin;
+	private final ServiceTracker<?, StartLevel> startlevel;
+	private final ServiceTracker<?, URLConverter> converter;
+	private final ServiceTracker<?, PlatformAdmin> platformAdmin;
 
 	public BundleInstaller(String bundlesRoot, BundleContext context) throws InvalidSyntaxException {
 		this.context = context;

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/dummys/DummyModuleDatabase.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/container/dummys/DummyModuleDatabase.java
@@ -29,8 +29,8 @@ public class DummyModuleDatabase extends ModuleDatabase {
 		super(adaptor);
 	}
 
-	private List<DummyModuleEvent> moduleEvents = new ArrayList<>();
-	private List<DummyContainerEvent> containerEvents = new ArrayList<>();
+	private final List<DummyModuleEvent> moduleEvents = new ArrayList<>();
+	private final List<DummyContainerEvent> containerEvents = new ArrayList<>();
 
 	void addEvent(DummyModuleEvent event) {
 		synchronized (moduleEvents) {

--- a/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/OSGiAPICertificateTest.java
+++ b/bundles/org.eclipse.osgi.tests/src/org/eclipse/osgi/tests/security/OSGiAPICertificateTest.java
@@ -71,7 +71,7 @@ public class OSGiAPICertificateTest extends BaseSecurityTest {
 	private static ConditionInfo info10True = new ConditionInfo(BundleSignerCondition.class.getName(),
 			new String[] { dnChain08True });
 
-	private Collection<Bundle> installedBundles = new ArrayList<>();
+	private final Collection<Bundle> installedBundles = new ArrayList<>();
 
 	private static String escapeStar(String dnChain) {
 		if (dnChain == null || dnChain.length() == 0)

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,39 @@
 
   <build>
     <plugins>
+	          </plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>cleanups</id>
+						<configuration>
+							<cleanUpProfile>
+								<!-- Make inner classes static where possible-->
+								<cleanup.static_inner_class>true</cleanup.static_inner_class>
+								<!-- Add missing annotations -->
+								<cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+								<!-- Add missing '@Deprecated' annotations-->
+								<cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+								<!-- Add missing '@Override' annotations to implementations of interface methods -->
+								<cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+								<!-- Use 'final' where possible -->
+								<cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+								<!-- Add final modifier to private fields -->
+								<cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+								<!-- Replace deprecated calls with inlined content where possible -->
+								<cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+							</cleanUpProfile>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
 
   <build>
     <plugins>
-	          </plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-cleancode-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

