### PR TITLE
Clean Code for bundles/org.eclipse.equinox.launcher

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.launcher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.launcher;singleton:=true
-Bundle-Version: 1.6.900.qualifier
+Bundle-Version: 1.6.1000.qualifier
 Main-Class: org.eclipse.equinox.launcher.Main
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/JNIBridge.java
@@ -36,7 +36,7 @@ class JNIBridge {
 
 	private native String _get_os_recommended_folder();
 
-	private String library;
+	private final String library;
 	private boolean libraryLoaded = false;
 
 	/**

--- a/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
+++ b/bundles/org.eclipse.equinox.launcher/src/org/eclipse/equinox/launcher/Main.java
@@ -2727,11 +2727,13 @@ public class Main {
 		}
 
 		// preparing for Java 9
+		@Override
 		protected URL findResource(String moduleName, String name) {
 			return findResource(name);
 		}
 
 		// preparing for Java 9
+		@Override
 		protected Class<?> findClass(String moduleName, String name) {
 			try {
 				return findClass(name);

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,20 @@
 
   <build>
     <plugins>
+
+
+		<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+                </plugin>
+
+
+
+
+	    
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

