### PR TITLE
Clean Code for bundles/org.eclipse.osgi

### DIFF
--- a/.github/workflows/checkDependencies.yml
+++ b/.github/workflows/checkDependencies.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 0 * * *'
 
 jobs:
   check-dependencies:

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,8 +4,6 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleDatabase.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleDatabase.java
@@ -514,6 +514,7 @@ public class ModuleDatabase {
 		try {
 			Map<ModuleRevision, ModuleWiring> clonedWirings = new HashMap<>(wirings);
 			clonedWirings.replaceAll(new BiFunction<ModuleRevision, ModuleWiring, ModuleWiring>() {
+				@Override
 				public ModuleWiring apply(ModuleRevision r, ModuleWiring w) {
 					return new ModuleWiring(r, w.getCapabilities(), w.getRequirements(), w.getProvidedWires(),
 							w.getRequiredWires(), w.getSubstitutedNames());

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolutionReport.java
@@ -81,11 +81,11 @@ class ModuleResolutionReport implements ResolutionReport {
 	private final Map<Resource, List<Entry>> entries;
 	private final ResolutionException resolutionException;
 	private final Map<Resource, List<Wire>> resolutionResult;
-	private int totalPerm;
-	private int processedPerm;
-	private int usesPerm;
-	private int subPerm;
-	private int importPerm;
+	private final int totalPerm;
+	private final int processedPerm;
+	private final int usesPerm;
+	private final int subPerm;
+	private final int importPerm;
 
 	ModuleResolutionReport(Map<Resource, List<Wire>> resolutionResult, Map<Resource, List<Entry>> entries,
 			ResolutionException cause, int totalPerm, int processedPerm, int usesPerm, int subPerm, int importPerm) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleResolver.java
@@ -507,10 +507,12 @@ final class ModuleResolver {
 				}
 			}
 
+			@Override
 			public void logRequirement(String message, Requirement requirement) {
 				debug(String.format(message, ModuleContainer.toString(requirement)));
 			}
 
+			@Override
 			public void logCapability(String message, Capability requirement) {
 				debug(String.format(message, ModuleContainer.toString(requirement)));
 			}
@@ -643,8 +645,8 @@ final class ModuleResolver {
 		private volatile boolean currentlyResolvingMandatory = false;
 		private final Set<Resource> transitivelyResolveFailures = new LinkedHashSet<>();
 		private final Set<Resource> failedToResolve = new HashSet<>();
-		private AtomicBoolean scheduleTimeout = new AtomicBoolean(true);
-		private AtomicReference<ScheduledFuture<?>> timoutFuture = new AtomicReference<>();
+		private final AtomicBoolean scheduleTimeout = new AtomicBoolean(true);
+		private final AtomicReference<ScheduledFuture<?>> timoutFuture = new AtomicReference<>();
 		/*
 		 * Used to generate the UNRESOLVED_PROVIDER resolution report entries.
 		 *

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevision.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevision.java
@@ -59,6 +59,7 @@ public final class ModuleRevision implements BundleRevision {
 
 	private NamespaceList<ModuleCapability> createCapabilities(NamespaceList.Builder<GenericInfo> capabilityInfos) {
 		return capabilityInfos.transformIntoCopy(new Function<GenericInfo, ModuleCapability>() {
+			@Override
 			public ModuleCapability apply(GenericInfo i) {
 				Map<String, String> directives = i.mutable ? copyUnmodifiableMap(i.directives) : i.directives;
 				Map<String, Object> attributes = i.mutable ? copyUnmodifiableMap(i.attributes) : i.attributes;
@@ -82,6 +83,7 @@ public final class ModuleRevision implements BundleRevision {
 
 	private NamespaceList<ModuleRequirement> createRequirements(NamespaceList.Builder<GenericInfo> infos) {
 		return infos.transformIntoCopy(new Function<GenericInfo, ModuleRequirement>() {
+			@Override
 			public ModuleRequirement apply(GenericInfo i) {
 				return new ModuleRequirement(i.namespace, i.directives, i.attributes, ModuleRevision.this);
 			}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevisionBuilder.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/ModuleRevisionBuilder.java
@@ -58,6 +58,7 @@ public final class ModuleRevisionBuilder {
 	 */
 	public static class GenericInfo {
 		final static Function<GenericInfo, String> GETNAMESPACE = new Function<GenericInfo, String>() {
+			@Override
 			public String apply(GenericInfo info) {
 				return info.getNamespace();
 			}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/namespaces/EquinoxModuleDataNamespace.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/container/namespaces/EquinoxModuleDataNamespace.java
@@ -69,6 +69,7 @@ public class EquinoxModuleDataNamespace extends Namespace {
 	 * 
 	 * @deprecated use {@link #LAZYSTART_HEADER}
 	 */
+	@Deprecated
 	public static final String AUTOSTART_HEADER = "Eclipse-AutoStart"; //$NON-NLS-1$
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/framework/util/Headers.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/framework/util/Headers.java
@@ -298,7 +298,7 @@ public class Headers<K, V> extends Dictionary<K, V> implements Map<K, V> {
 	}
 
 	private static class ArrayEnumeration<E> implements Enumeration<E> {
-		private E[] array;
+		private final E[] array;
 		int cur = 0;
 
 		public ArrayEnumeration(E[] array, int size) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/framework/util/SecureAction.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/framework/util/SecureAction.java
@@ -45,7 +45,7 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 public class SecureAction {
 	// make sure we use the correct controlContext;
-	private AccessControlContext controlContext;
+	private final AccessControlContext controlContext;
 
 	// uses initialization-on-demand holder idiom to do fast lazy loading
 	private static class BootClassLoaderHolder {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/connect/ConnectInputStream.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/connect/ConnectInputStream.java
@@ -44,6 +44,7 @@ public class ConnectInputStream extends InputStream implements ContentProvider {
 		throw new IOException();
 	}
 
+	@Override
 	public File getContent() {
 		return null;
 	}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/ComputeNodeOrder.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/ComputeNodeOrder.java
@@ -109,14 +109,14 @@ public class ComputeNodeOrder {
 		 *
 		 * Element type: <code>Vertex</code>
 		 */
-		private List<Vertex> vertexList = new ArrayList<>(100);
+		private final List<Vertex> vertexList = new ArrayList<>(100);
 
 		/**
 		 * Map from id to vertex.
 		 *
 		 * Key type: <code>Object</code>; value type: <code>Vertex</code>
 		 */
-		private Map<Object, Vertex> vertexMap = new HashMap<>(100);
+		private final Map<Object, Vertex> vertexMap = new HashMap<>(100);
 
 		/**
 		 * DFS visit time. Non-negative.

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/NamespaceList.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/container/NamespaceList.java
@@ -47,16 +47,19 @@ import org.eclipse.osgi.container.ModuleWire;
 public class NamespaceList<E> {
 
 	public final static Function<ModuleWire, String> WIRE = new Function<ModuleWire, String>() {
+		@Override
 		public String apply(ModuleWire wire) {
 			return wire.getCapability().getNamespace();
 		}
 	};
 	public final static Function<ModuleCapability, String> CAPABILITY = new Function<ModuleCapability, String>() {
+		@Override
 		public String apply(ModuleCapability capability) {
 			return capability.getNamespace();
 		}
 	};
 	public final static Function<ModuleRequirement, String> REQUIREMENT = new Function<ModuleRequirement, String>() {
+		@Override
 		public String apply(ModuleRequirement requirement) {
 			return requirement.getNamespace();
 		}
@@ -188,6 +191,7 @@ public class NamespaceList<E> {
 					return inner.hasNext();
 				}
 
+				@Override
 				public E next() {
 					if (!hasNext()) {
 						throw new NoSuchElementException();
@@ -333,6 +337,7 @@ public class NamespaceList<E> {
 
 		private List<E> getNamespaceList(String namespace) {
 			return namespaceElements.computeIfAbsent(namespace, new Function<String, List<E>>() {
+				@Override
 				public List<E> apply(String n) {
 					return new ArrayList<>();
 				}
@@ -402,6 +407,7 @@ public class NamespaceList<E> {
 								targetList.add(toAdd);
 							} else {
 								addAfterLastMatch(toAdd, targetList, new Predicate<E>() {
+									@Override
 									public boolean test(E e) {
 										return insertionMatcher.test(toAdd, e);
 									}
@@ -448,6 +454,7 @@ public class NamespaceList<E> {
 
 		private void removeNamespaceElement(String namespace, E element) {
 			namespaceElements.computeIfPresent(namespace, new BiFunction<String, List<E>, List<E>>() {
+				@Override
 				public List<E> apply(String n, List<E> es) {
 					if (es.remove(element)) {
 						Builder.this.size--;
@@ -482,6 +489,7 @@ public class NamespaceList<E> {
 			prepareModification();
 
 			namespaceElements.entrySet().removeIf(new Predicate<Map.Entry<String, List<E>>>() {
+				@Override
 				public boolean test(Map.Entry<String, List<E>> e) {
 					if (filter.test(e.getKey())) {
 						Builder.this.size -= e.getValue().size();
@@ -498,6 +506,7 @@ public class NamespaceList<E> {
 
 			int s = size;
 			namespaceElements.values().removeIf(new Predicate<List<E>>() {
+				@Override
 				public boolean test(List<E> es) {
 					return removeElementsIf(es, filter) == null;
 				}
@@ -516,6 +525,7 @@ public class NamespaceList<E> {
 			prepareModification();
 
 			namespaceElements.computeIfPresent(namespace, new BiFunction<String, List<E>, List<E>>() {
+				@Override
 				public List<E> apply(String n, List<E> es) {
 					return removeElementsIf(es, filter);
 				}
@@ -555,6 +565,7 @@ public class NamespaceList<E> {
 
 				int[] start = new int[] { 0 };
 				namespaceElements.replaceAll(new BiFunction<String, List<E>, List<E>>() {
+					@Override
 					public List<E> apply(String n, List<E> es) {
 						int from = start[0];
 						int to = start[0] += es.size();
@@ -571,6 +582,7 @@ public class NamespaceList<E> {
 				// namespace-lists for subsequent modification
 				namespaceElements = new LinkedHashMap<>(namespaceElements);
 				namespaceElements.replaceAll(new BiFunction<String, List<E>, List<E>>() {
+					@Override
 					public List<E> apply(String n, List<E> es) {
 						return new ArrayList<>(es);
 					}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxEventPublisher.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/EquinoxEventPublisher.java
@@ -54,7 +54,7 @@ public class EquinoxEventPublisher {
 
 	private final EquinoxContainer container;
 
-	private Object monitor = new Object();
+	private final Object monitor = new Object();
 	private EventManager eventManager;
 
 	/*

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/FilterImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/FilterImpl.java
@@ -1653,7 +1653,7 @@ public abstract class FilterImpl implements Filter {
 		private Version leftVersion;
 		private Version rightVersion;
 		private char rightRule = 0;
-		private Collection<Version> excludes = new ArrayList<>(0);
+		private final Collection<Version> excludes = new ArrayList<>(0);
 
 		@Override
 		public String toString() {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/SystemBundleActivator.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/SystemBundleActivator.java
@@ -57,7 +57,7 @@ import org.osgi.service.startlevel.StartLevel;
 
 public class SystemBundleActivator implements BundleActivator {
 	private EquinoxFactoryManager urlFactoryManager;
-	private List<ServiceRegistration<?>> registrations = new ArrayList<>(10);
+	private final List<ServiceRegistration<?>> registrations = new ArrayList<>(10);
 	private SecurityManager setSecurityManagner;
 
 	@SuppressWarnings("deprecation")

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/legacy/PackageAdminImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/legacy/PackageAdminImpl.java
@@ -378,6 +378,7 @@ public class PackageAdminImpl implements PackageAdmin {
 		/**
 		 * @deprecated
 		 */
+		@Deprecated
 		@Override
 		public String getSpecificationVersion() {
 			return getVersion().toString();

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/ModuleClassLoader.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/ModuleClassLoader.java
@@ -101,6 +101,7 @@ public abstract class ModuleClassLoader extends ClassLoader implements BundleRef
 
 	private static final class ClassNameLock {
 		static final Function<String, ClassNameLock> SUPPLIER = new Function<String, ClassNameLock>() {
+			@Override
 			public ClassNameLock apply(String className) {
 				return new ClassNameLock(className);
 			}
@@ -201,6 +202,7 @@ public abstract class ModuleClassLoader extends ClassLoader implements BundleRef
 	}
 
 	// preparing for Java 9
+	@Override
 	protected Class<?> findClass(String moduleName, String name) {
 		try {
 			return findLocalClass(name);
@@ -244,6 +246,7 @@ public abstract class ModuleClassLoader extends ClassLoader implements BundleRef
 	}
 
 	// preparing for Java 9
+	@Override
 	protected URL findResource(String moduleName, String name) {
 		return findLocalResource(name);
 	}

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/buddy/GlobalPolicy.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/buddy/GlobalPolicy.java
@@ -39,7 +39,7 @@ import org.osgi.resource.Namespace;
  * with the highest version will be returned.
  */
 public class GlobalPolicy implements IBuddyPolicy {
-	private FrameworkWiring frameworkWiring;
+	private final FrameworkWiring frameworkWiring;
 
 	public GlobalPolicy(FrameworkWiring frameworkWiring) {
 		this.frameworkWiring = frameworkWiring;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/classpath/ClasspathManager.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/loader/classpath/ClasspathManager.java
@@ -83,7 +83,7 @@ public class ClasspathManager {
 	private ArrayMap<String, String> loadedLibraries = null;
 	// used to detect recusive defineClass calls for the same class on the same
 	// class loader (bug 345500)
-	private ThreadLocal<DefineContext> currentDefineContext = new ThreadLocal<>();
+	private final ThreadLocal<DefineContext> currentDefineContext = new ThreadLocal<>();
 
 	/**
 	 * Constructs a classpath manager for the given generation and module class

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/location/BasicLocation.java
@@ -119,6 +119,7 @@ public class BasicLocation implements Location {
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public boolean setURL(URL value, boolean lock) throws IllegalStateException {
 		try {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/EventAdminAdapter.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/EventAdminAdapter.java
@@ -33,12 +33,12 @@ public class EventAdminAdapter implements ServiceTrackerCustomizer<Object, Objec
 	private static Collection<String> eventAdminObjectClass = Arrays.asList("org.osgi.service.event.EventAdmin"); //$NON-NLS-1$
 	private static Collection<String> eventHandlerObjectClass = Arrays.asList("org.osgi.service.event.EventHandler"); //$NON-NLS-1$
 
-	private ServiceTracker<Object, Object> eventAdminTracker;
-	private ServiceTracker<Object, Object> eventHandlerTracker;
-	private BundleContext context;
+	private final ServiceTracker<Object, Object> eventAdminTracker;
+	private final ServiceTracker<Object, Object> eventHandlerTracker;
+	private final BundleContext context;
 	private ServiceReference<Object> eventAdmin;
 	private int logEventHandlers;
-	private ExtendedLogReaderServiceFactory logReaderServiceFactory;
+	private final ExtendedLogReaderServiceFactory logReaderServiceFactory;
 	private EventAdminLogListener logListener;
 
 	public EventAdminAdapter(BundleContext context, ExtendedLogReaderServiceFactory logReaderServiceFactory) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/ExtendedLogReaderServiceFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/log/ExtendedLogReaderServiceFactory.java
@@ -420,7 +420,7 @@ class OrderedExecutor implements ThreadFactory {
 	 */
 	class OrderedTaskQueue {
 		private final Queue<OrderedTask> dependencyQueue = new LinkedList<>();
-		private AtomicReference<OrderedTask> firstTask = new AtomicReference<>();
+		private final AtomicReference<OrderedTask> firstTask = new AtomicReference<>();
 
 		void execute(Runnable task, int numListeners) {
 			executeOrderedTask(task, this, numListeners);

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityAdmin.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityAdmin.java
@@ -255,6 +255,7 @@ public final class SecurityAdmin implements PermissionAdmin, ConditionalPermissi
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public ConditionalPermissionInfo addConditionalPermissionInfo(ConditionInfo[] conds, PermissionInfo[] perms) {
 		return setConditionalPermissionInfo(null, conds, perms, true);
@@ -287,6 +288,7 @@ public final class SecurityAdmin implements PermissionAdmin, ConditionalPermissi
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public ConditionalPermissionInfo getConditionalPermissionInfo(String name) {
 		synchronized (lock) {
@@ -297,6 +299,7 @@ public final class SecurityAdmin implements PermissionAdmin, ConditionalPermissi
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public Enumeration<ConditionalPermissionInfo> getConditionalPermissionInfos() {
 		// could implement our own Enumeration, but we don't care about performance
@@ -312,6 +315,7 @@ public final class SecurityAdmin implements PermissionAdmin, ConditionalPermissi
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public ConditionalPermissionInfo setConditionalPermissionInfo(String name, ConditionInfo[] conds,
 			PermissionInfo[] perms) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityRow.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityRow.java
@@ -253,6 +253,7 @@ public final class SecurityRow implements ConditionalPermissionInfo {
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public void delete() {
 		securityAdmin.delete(this, true);

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityRowSnapShot.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/permadmin/SecurityRowSnapShot.java
@@ -64,6 +64,7 @@ public class SecurityRowSnapShot implements ConditionalPermissionInfo {
 	/**
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public void delete() {
 		throw new UnsupportedOperationException();

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/provisional/service/security/AuthorizationEngine.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/provisional/service/security/AuthorizationEngine.java
@@ -29,8 +29,8 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 public abstract class AuthorizationEngine {
 
-	private EventManager manager = new EventManager();
-	private EventDispatcher<AuthorizationListener, Object, AuthorizationEvent> dispatcher = new AuthEventDispatcher();
+	private final EventManager manager = new EventManager();
+	private final EventDispatcher<AuthorizationListener, Object, AuthorizationEvent> dispatcher = new AuthEventDispatcher();
 	private final ServiceTracker<AuthorizationListener, AuthorizationListener> listenerTracker;
 
 	public AuthorizationEngine(BundleContext context) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/signedcontent/BundleToJarInputStream.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/signedcontent/BundleToJarInputStream.java
@@ -99,6 +99,7 @@ public final class BundleToJarInputStream extends InputStream {
 		return false;
 	}
 
+	@Override
 	public int read() throws IOException {
 		if (nextEntryInput != null) {
 			int result = nextEntryInput.read();

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/ContentHandlerFactoryImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/ContentHandlerFactoryImpl.java
@@ -40,7 +40,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * content handler.
  */
 public class ContentHandlerFactoryImpl extends MultiplexingFactory implements java.net.ContentHandlerFactory {
-	private ServiceTracker<ContentHandler, ContentHandler> contentHandlerTracker;
+	private final ServiceTracker<ContentHandler, ContentHandler> contentHandlerTracker;
 
 	private static final String contentHandlerClazz = "java.net.ContentHandler"; //$NON-NLS-1$
 	private static final String CONTENT_HANDLER_PKGS = "java.content.handler.pkgs"; //$NON-NLS-1$
@@ -49,7 +49,7 @@ public class ContentHandlerFactoryImpl extends MultiplexingFactory implements ja
 	private static final List<Class<?>> ignoredClasses = Arrays.asList(
 			new Class<?>[] { MultiplexingContentHandler.class, ContentHandlerFactoryImpl.class, URLConnection.class });
 
-	private Map<String, ContentHandlerProxy> proxies;
+	private final Map<String, ContentHandlerProxy> proxies;
 	private java.net.ContentHandlerFactory parentFactory;
 
 	public ContentHandlerFactoryImpl(BundleContext context, EquinoxContainer container) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/MultiplexingContentHandler.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/MultiplexingContentHandler.java
@@ -17,8 +17,8 @@ import java.net.URLConnection;
 
 public class MultiplexingContentHandler extends ContentHandler {
 
-	private String contentType;
-	private ContentHandlerFactoryImpl factory;
+	private final String contentType;
+	private final ContentHandlerFactoryImpl factory;
 
 	public MultiplexingContentHandler(String contentType, ContentHandlerFactoryImpl factory) {
 		this.contentType = contentType;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/MultiplexingURLStreamHandler.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/MultiplexingURLStreamHandler.java
@@ -32,8 +32,8 @@ public class MultiplexingURLStreamHandler extends URLStreamHandler {
 	private static Field handlerField;
 	private static boolean methodsInitialized = false;
 
-	private String protocol;
-	private URLStreamHandlerFactoryImpl factory;
+	private final String protocol;
+	private final URLStreamHandlerFactoryImpl factory;
 	private final URLStreamHandler authorized;
 
 	private static synchronized void initializeMethods(URLStreamHandlerFactoryImpl factory) {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerFactoryImpl.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerFactoryImpl.java
@@ -43,9 +43,9 @@ public class URLStreamHandlerFactoryImpl extends MultiplexingFactory implements 
 
 	private static final List<Class<?>> ignoredClasses = Arrays.asList(
 			new Class<?>[] { MultiplexingURLStreamHandler.class, URLStreamHandlerFactoryImpl.class, URL.class });
-	private Map<String, URLStreamHandlerProxy> proxies;
+	private final Map<String, URLStreamHandlerProxy> proxies;
 	private URLStreamHandlerFactory parentFactory;
-	private ThreadLocal<List<String>> creatingProtocols = new ThreadLocal<>();
+	private final ThreadLocal<List<String>> creatingProtocols = new ThreadLocal<>();
 
 	/**
 	 * Create the factory.

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerProxy.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerProxy.java
@@ -214,8 +214,8 @@ public class URLStreamHandlerProxy extends URLStreamHandler {
 
 	private static final class LazyURLStreamHandlerService implements Supplier<URLStreamHandlerService> {
 
-		private BundleContext bundleContext;
-		private ServiceReference<URLStreamHandlerService> reference;
+		private final BundleContext bundleContext;
+		private final ServiceReference<URLStreamHandlerService> reference;
 		private URLStreamHandlerService service;
 		private boolean disposed;
 

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerSetter.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/url/URLStreamHandlerSetter.java
@@ -29,6 +29,7 @@ public class URLStreamHandlerSetter implements org.osgi.service.url.URLStreamHan
 	 *      int, String, String)
 	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public void setURL(URL url, String protocol, String host, int port, String file, String ref) {
 		handlerProxy.setURL(url, protocol, host, port, file, ref);

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/BundleDelta.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/BundleDelta.java
@@ -71,6 +71,7 @@ public interface BundleDelta extends Comparable<BundleDelta> {
 	 * @see BundleDelta#getType
 	 * @deprecated this type is no longer valid
 	 */
+	@Deprecated
 	public static final int LINKAGE_CHANGED = 0x20;
 
 	/**
@@ -80,6 +81,7 @@ public interface BundleDelta extends Comparable<BundleDelta> {
 	 * @see BundleDelta#getType
 	 * @deprecated this type is no longer valid
 	 */
+	@Deprecated
 	public static final int OPTIONAL_LINKAGE_CHANGED = 0x40;
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/ExportPackageDescription.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/ExportPackageDescription.java
@@ -37,6 +37,7 @@ public interface ExportPackageDescription extends BaseDescription {
 	 * @deprecated all export package descriptions are roots. The Reexport-Package
 	 *             header never became API.
 	 */
+	@Deprecated
 	public boolean isRoot();
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/GenericDescription.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/GenericDescription.java
@@ -51,6 +51,7 @@ public interface GenericDescription extends BaseDescription {
 	 * 
 	 * @deprecated matching should only be done against a capability's attributes.
 	 */
+	@Deprecated
 	@Override
 	public String getName();
 
@@ -63,6 +64,7 @@ public interface GenericDescription extends BaseDescription {
 	 * 
 	 * @deprecated matching should only be done against a capability's attributes.
 	 */
+	@Deprecated
 	@Override
 	public Version getVersion();
 }

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/PlatformAdmin.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/PlatformAdmin.java
@@ -93,6 +93,7 @@ public interface PlatformAdmin {
 	 * @return a system resolver
 	 * @deprecated in favour of {@link #createResolver()}.
 	 */
+	@Deprecated
 	public Resolver getResolver();
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/State.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/State.java
@@ -208,6 +208,7 @@ public interface State {
 	 * @deprecated use
 	 *             {@link #resolveBundle(BundleDescription, boolean, BundleDescription[], ExportPackageDescription[], ExportPackageDescription[], GenericDescription[], BundleDescription[], ExportPackageDescription[], GenericDescription[], Map)}
 	 */
+	@Deprecated
 	public void resolveBundle(BundleDescription bundle, boolean status, BundleDescription[] hosts,
 			ExportPackageDescription[] selectedExports, BundleDescription[] resolvedRequires,
 			ExportPackageDescription[] resolvedImports);
@@ -240,6 +241,7 @@ public interface State {
 	 * @deprecated use
 	 *             {@link #resolveBundle(BundleDescription, boolean, BundleDescription[], ExportPackageDescription[], ExportPackageDescription[], GenericDescription[], BundleDescription[], ExportPackageDescription[], GenericDescription[], Map)}
 	 */
+	@Deprecated
 	public void resolveBundle(BundleDescription bundle, boolean status, BundleDescription[] hosts,
 			ExportPackageDescription[] selectedExports, ExportPackageDescription[] substitutedExports,
 			BundleDescription[] resolvedRequires, ExportPackageDescription[] resolvedImports);
@@ -438,6 +440,7 @@ public interface State {
 	 * @deprecated The exact form of this has never been defined. There is no
 	 *             alternative method available.
 	 */
+	@Deprecated
 	public void setOverrides(Object value);
 
 	/**

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/StateObjectFactory.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/StateObjectFactory.java
@@ -51,6 +51,7 @@ public interface StateObjectFactory {
 	 * @return the created state
 	 * @deprecated use {@link #createState(boolean) }
 	 */
+	@Deprecated
 	public State createState();
 
 	/**
@@ -99,6 +100,7 @@ public interface StateObjectFactory {
 	 * @deprecated use
 	 *             {@link #createBundleDescription(long, String, Version, String, BundleSpecification[], HostSpecification, ImportPackageSpecification[], ExportPackageDescription[], boolean, boolean, boolean, String, String[], GenericSpecification[], GenericDescription[])}
 	 */
+	@Deprecated
 	public BundleDescription createBundleDescription(long id, String symbolicName, Version version, String location,
 			BundleSpecification[] required, HostSpecification host, ImportPackageSpecification[] imports,
 			ExportPackageDescription[] exports, String[] providedPackages, boolean singleton);
@@ -138,6 +140,7 @@ public interface StateObjectFactory {
 	 * @deprecated use
 	 *             {@link #createBundleDescription(long, String, Version, String, BundleSpecification[], HostSpecification, ImportPackageSpecification[], ExportPackageDescription[], boolean, boolean, boolean, String, String[], GenericSpecification[], GenericDescription[])}
 	 */
+	@Deprecated
 	public BundleDescription createBundleDescription(long id, String symbolicName, Version version, String location,
 			BundleSpecification[] required, HostSpecification host, ImportPackageSpecification[] imports,
 			ExportPackageDescription[] exports, String[] providedPackages, boolean singleton, boolean attachFragments,
@@ -292,6 +295,7 @@ public interface StateObjectFactory {
 	 * @deprecated use
 	 *             {@link #createBundleDescription(State, Dictionary, String, long)}
 	 */
+	@Deprecated
 	public BundleDescription createBundleDescription(Dictionary<String, String> manifest, String location, long id)
 			throws BundleException;
 
@@ -435,6 +439,7 @@ public interface StateObjectFactory {
 	 * @deprecated use
 	 *             {@link #createGenericDescription(String, String, Version, Map)}
 	 */
+	@Deprecated
 	public GenericDescription createGenericDescription(String name, String type, Version version,
 			Map<String, ?> attributes);
 
@@ -551,6 +556,7 @@ public interface StateObjectFactory {
 	 * @deprecated use {@link #writeState(State, File)} instead
 	 * @since 3.1
 	 */
+	@Deprecated
 	public void writeState(State state, OutputStream stream) throws IOException;
 
 	/**
@@ -565,6 +571,7 @@ public interface StateObjectFactory {
 	 * @deprecated use {@link #writeState(State, File)} instead
 	 * @see #writeState(State, OutputStream)
 	 */
+	@Deprecated
 	public void writeState(State state, DataOutputStream stream) throws IOException;
 
 	/**
@@ -589,6 +596,7 @@ public interface StateObjectFactory {
 	 * @deprecated use {@link #readState(File)} instead
 	 * @since 3.1
 	 */
+	@Deprecated
 	public State readState(InputStream stream) throws IOException;
 
 	/**
@@ -601,6 +609,7 @@ public interface StateObjectFactory {
 	 * @deprecated use {@link #readState(File)} instead
 	 * @see #readState(InputStream)
 	 */
+	@Deprecated
 	public State readState(DataInputStream stream) throws IOException;
 
 	/**
@@ -615,7 +624,7 @@ public interface StateObjectFactory {
 
 	static class StateObjectFactoryProxy implements StateObjectFactory {
 		private static final String IMPL_NAME = "org.eclipse.osgi.internal.resolver.StateObjectFactoryImpl"; //$NON-NLS-1$
-		private Object monitor = new Object();
+		private final Object monitor = new Object();
 		private StateObjectFactory implementation;
 
 		private StateObjectFactory getImplementation() {

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/VersionRange.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/service/resolver/VersionRange.java
@@ -105,6 +105,7 @@ public class VersionRange extends org.osgi.framework.VersionRange {
 	 * @return the maximum Version of this VersionRange
 	 * @deprecated use {@link org.osgi.framework.VersionRange#getRight()}
 	 */
+	@Deprecated
 	public Version getMaximum() {
 		Version right = getRight();
 		return right == null ? versionMax : right;

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/signedcontent/SignerInfo.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/signedcontent/SignerInfo.java
@@ -58,6 +58,7 @@ public interface SignerInfo {
 	 * @deprecated This information is not readily available using the JAR APIs
 	 *             included with Java. A value {@literal unknown} will be returned.
 	 */
+	@Deprecated
 	public String getMessageDigestAlgorithm();
 
 }

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/bundlefile/DirZipBundleEntry.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/bundlefile/DirZipBundleEntry.java
@@ -28,7 +28,7 @@ public class DirZipBundleEntry extends BundleEntry {
 	/**
 	 * ZipBundleFile for this entry.
 	 */
-	private ZipBundleFile bundleFile;
+	private final ZipBundleFile bundleFile;
 	/**
 	 * The name for this entry
 	 */

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/Candidates.java
@@ -1231,11 +1231,13 @@ class Candidates
             this.requirement = requirement;
         }
 
-        public String getMessage() {
+        @Override
+		public String getMessage() {
             return "Dynamic import failed.";
         }
 
-        public Collection<Requirement> getUnresolvedRequirements() {
+        @Override
+		public Collection<Requirement> getUnresolvedRequirements() {
             return Collections.singleton(requirement);
         }
 
@@ -1254,7 +1256,8 @@ class Candidates
             this.resource = resource;
         }
 
-        public String getMessage() {
+        @Override
+		public String getMessage() {
             return "Fragment was not selected for attachment: " + resource;
         }
 
@@ -1284,7 +1287,8 @@ class Candidates
             this.cause = cause;
         }
 
-        public String getMessage() {
+        @Override
+		public String getMessage() {
             String msg = "Unable to resolve " + requirement.getResource()
                     + ": missing requirement " + requirement;
             if (cause != null)
@@ -1294,7 +1298,8 @@ class Candidates
             return msg;
         }
 
-        public Collection<Requirement> getUnresolvedRequirements() {
+        @Override
+		public Collection<Requirement> getUnresolvedRequirements() {
             return Collections.singleton(requirement);
         }
 

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ResolverImpl.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/ResolverImpl.java
@@ -89,9 +89,9 @@ public class ResolverImpl implements Resolver
         private final List<Capability> m_dynamicCandidates;
         // keeps track of valid related resources that we have seen.
         // a null value or TRUE indicate it is valid
-        private Map<Resource, Boolean> m_validRelatedResources = new HashMap<Resource, Boolean>(0);
+        private final Map<Resource, Boolean> m_validRelatedResources = new HashMap<Resource, Boolean>(0);
         // keeps track of related resources for each resource
-        private Map<Resource, Collection<Resource>> m_relatedResources = new HashMap<Resource, Collection<Resource>>(0);
+        private final Map<Resource, Collection<Resource>> m_relatedResources = new HashMap<Resource, Collection<Resource>>(0);
         // Holds candidate permutations based on permutating "uses" chains.
         // These permutations are given higher priority.
         private final List<Candidates> m_usesPermutations = new LinkedList<Candidates>();
@@ -408,7 +408,8 @@ public class ResolverImpl implements Resolver
         this.m_executor = executor;
     }
 
-    public Map<Resource, List<Wire>> resolve(ResolveContext rc) throws ResolutionException
+    @Override
+	public Map<Resource, List<Wire>> resolve(ResolveContext rc) throws ResolutionException
     {
         if (m_executor != null)
         {
@@ -421,7 +422,8 @@ public class ResolverImpl implements Resolver
                     AccessController.doPrivileged(
                         new PrivilegedAction<ExecutorService>()
                         {
-                            public ExecutorService run()
+                            @Override
+							public ExecutorService run()
                             {
                                 return Executors.newFixedThreadPool(m_parallelism);
                             }
@@ -437,7 +439,8 @@ public class ResolverImpl implements Resolver
                 if (System.getSecurityManager() != null)
                 {
                     AccessController.doPrivileged(new PrivilegedAction<Void>(){
-                        public Void run() {
+                        @Override
+						public Void run() {
                             executor.shutdownNow();
                             return null;
                         }
@@ -686,7 +689,8 @@ public class ResolverImpl implements Resolver
         return error;
     }
 
-    public Map<Resource,List<Wire>> resolveDynamic(ResolveContext context,
+    @Override
+	public Map<Resource,List<Wire>> resolveDynamic(ResolveContext context,
             Wiring hostWiring, Requirement dynamicRequirement)
             throws ResolutionException
     {
@@ -1182,7 +1186,8 @@ public class ResolverImpl implements Resolver
                 {
                     this.resource = resource;
                 }
-                public void run()
+                @Override
+				public void run()
                 {
                     List<WireCandidate> wireCandidates = getWireCandidates(session, allCandidates, resource);
                     allWireCandidates.put(resource, wireCandidates);
@@ -1215,7 +1220,8 @@ public class ResolverImpl implements Resolver
             allPackages.put(resource, packages);
             executor.execute(new Runnable()
             {
-                public void run()
+                @Override
+				public void run()
                 {
                     calculateExportedPackages(session, allCandidates, resource,
                         packages.m_exportedPkgs, packages.m_substitePkgs);
@@ -1229,7 +1235,8 @@ public class ResolverImpl implements Resolver
         {
             executor.execute(new Runnable()
             {
-                public void run()
+                @Override
+				public void run()
                 {
                     getPackages(session, allCandidates, allWireCandidates, allPackages, resource, allPackages.get(resource));
                 }
@@ -1260,7 +1267,8 @@ public class ResolverImpl implements Resolver
             {
                 executor.execute(new Runnable()
                 {
-                    public void run()
+                    @Override
+					public void run()
                     {
                         getPackageSourcesInternal(session, allPackages, resource, packages);
                     }
@@ -1274,7 +1282,8 @@ public class ResolverImpl implements Resolver
         {
             executor.execute(new Runnable()
             {
-                public void run()
+                @Override
+				public void run()
                 {
                     computeUses(session, allWireCandidates, allPackages, resource);
                 }
@@ -1821,7 +1830,8 @@ public class ResolverImpl implements Resolver
                 : resource.getCapabilities(null);
         @SuppressWarnings("serial")
         OpenHashMap<String, Set<Capability>> pkgs = new OpenHashMap<String, Set<Capability>>(caps.size()) {
-            public Set<Capability> compute(String pkgName) {
+            @Override
+			public Set<Capability> compute(String pkgName) {
                 return new HashSet<Capability>();
             }
         };
@@ -2173,12 +2183,14 @@ public class ResolverImpl implements Resolver
             m_exportedPkgs = new OpenHashMap<String, Blame>(nbCaps);
             m_substitePkgs = new OpenHashMap<String, Blame>(nbCaps);
             m_importedPkgs = new OpenHashMap<String, List<Blame>>(nbReqs) {
-                public List<Blame> compute(String s) {
+                @Override
+				public List<Blame> compute(String s) {
                     return new ArrayList<Blame>();
                 }
             };
             m_requiredPkgs = new OpenHashMap<String, List<Blame>>(nbReqs) {
-                public List<Blame> compute(String s) {
+                @Override
+				public List<Blame> compute(String s) {
                     return new ArrayList<Blame>();
                 }
             };
@@ -2328,7 +2340,8 @@ public class ResolverImpl implements Resolver
             this.m_blame2 = blame2;
         }
 
-        public String getMessage() {
+        @Override
+		public String getMessage() {
             if (m_blame2 == null)
             {
                 return "Uses constraint violation. Unable to resolve resource "
@@ -2362,7 +2375,8 @@ public class ResolverImpl implements Resolver
             }
         }
 
-        public Collection<Requirement> getUnresolvedRequirements() {
+        @Override
+		public Collection<Requirement> getUnresolvedRequirements() {
             if (m_blame2 == null)
             {
                 // This is an export conflict so there is only the first blame;
@@ -2525,7 +2539,8 @@ public class ResolverImpl implements Resolver
         {
             FutureTask<Void> task = new FutureTask<Void>(new Runnable()
             {
-                public void run()
+                @Override
+				public void run()
                 {
                     try
                     {
@@ -2595,7 +2610,8 @@ public class ResolverImpl implements Resolver
 
     static class DumbExecutor implements Executor
     {
-        public void execute(Runnable command)
+        @Override
+		public void execute(Runnable command)
         {
             command.run();
         }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/SimpleHostedCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/SimpleHostedCapability.java
@@ -34,27 +34,32 @@ class SimpleHostedCapability implements HostedCapability
         m_cap = cap;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_host;
     }
 
-    public Capability getDeclaredCapability()
+    @Override
+	public Capability getDeclaredCapability()
     {
         return m_cap;
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return m_cap.getNamespace();
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_cap.getDirectives();
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_cap.getAttributes();
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WireImpl.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WireImpl.java
@@ -40,22 +40,26 @@ class WireImpl implements Wire
         m_cap = cap;
     }
 
-    public Resource getRequirer()
+    @Override
+	public Resource getRequirer()
     {
         return m_requirer;
     }
 
-    public Requirement getRequirement()
+    @Override
+	public Requirement getRequirement()
     {
         return m_req;
     }
 
-    public Resource getProvider()
+    @Override
+	public Resource getProvider()
     {
         return m_provider;
     }
 
-    public Capability getCapability()
+    @Override
+	public Capability getCapability()
     {
         return m_cap;
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedCapability.java
@@ -80,27 +80,32 @@ public class WrappedCapability implements HostedCapability
         return hash;
     }
 
-    public Capability getDeclaredCapability()
+    @Override
+	public Capability getDeclaredCapability()
     {
         return m_cap;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_host;
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return m_cap.getNamespace();
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_cap.getDirectives();
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_augmentedAttrs;
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedRequirement.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedRequirement.java
@@ -71,22 +71,26 @@ public class WrappedRequirement implements Requirement
         return m_req;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_host;
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return m_req.getNamespace();
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_req.getDirectives();
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_req.getAttributes();
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedResource.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/WrappedResource.java
@@ -95,7 +95,8 @@ class WrappedResource implements Resource
         return m_fragments;
     }
 
-    public List<Capability> getCapabilities(String namespace)
+    @Override
+	public List<Capability> getCapabilities(String namespace)
     {
         if (namespace != null) {
             List<Capability> filtered = new ArrayList<Capability>();
@@ -109,7 +110,8 @@ class WrappedResource implements Resource
         return m_cachedCapabilities;
     }
 
-    public List<Requirement> getRequirements(String namespace)
+    @Override
+	public List<Requirement> getRequirements(String namespace)
     {
         if (namespace != null) {
             List<Requirement> filtered = new ArrayList<Requirement>();
@@ -123,7 +125,8 @@ class WrappedResource implements Resource
         return m_cachedRequirements;
     }
 
-    public String toString()
+    @Override
+	public String toString()
     {
         return m_host.toString();
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ArrayMap.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ArrayMap.java
@@ -99,11 +99,13 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> {
                     return new Iterator<V>() {
                         int index = 0;
 
-                        public boolean hasNext() {
+                        @Override
+						public boolean hasNext() {
                             return index < size;
                         }
 
-                        @SuppressWarnings("unchecked")
+                        @Override
+						@SuppressWarnings("unchecked")
                         public V next() {
                             if (index >= size) {
                                 throw new NoSuchElementException();
@@ -111,7 +113,8 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> {
                             return (V) table[(index++ << 1) + 1];
                         }
                         
-                        public void remove() {
+                        @Override
+						public void remove() {
                             throw new UnsupportedOperationException();
                         }
                     };
@@ -135,11 +138,13 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> {
                     FastEntry<K, V> entry = new FastEntry<K, V>();
                     int index = 0;
 
-                    public boolean hasNext() {
+                    @Override
+					public boolean hasNext() {
                         return index < size;
                     }
 
-                    @SuppressWarnings("unchecked")
+                    @Override
+					@SuppressWarnings("unchecked")
                     public FastEntry<K, V> next() {
                         if (index >= size) {
                             throw new NoSuchElementException();
@@ -151,7 +156,8 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> {
                         return entry;
                     }
 
-                    public void remove() {
+                    @Override
+					public void remove() {
                         throw new UnsupportedOperationException();
                     }
                 };
@@ -168,16 +174,19 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> {
         K key;
         V value;
 
-        public K getKey() {
+        @Override
+		public K getKey() {
             return key;
         }
 
 
-        public V getValue() {
+        @Override
+		public V getValue() {
             return value;
         }
 
-        public V setValue(V value) {
+        @Override
+		public V setValue(V value) {
             throw new UnsupportedOperationException();
         }
     }

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CandidateSelector.java
@@ -69,7 +69,8 @@ public class CandidateSelector {
         return current;
     }
 
-    public String toString() {
+    @Override
+	public String toString() {
         return getRemainingCandidates().toString();
     }
 

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CopyOnWriteSet.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/CopyOnWriteSet.java
@@ -40,27 +40,33 @@ public class CopyOnWriteSet<E> implements Set<E>, Cloneable {
         data = col.toArray(new Object[col.size()]);
     }
 
-    public Iterator<E> iterator() {
+    @Override
+	public Iterator<E> iterator() {
         return new Iterator<E>() {
             int idx = 0;
-            public boolean hasNext() {
+            @Override
+			public boolean hasNext() {
                 return idx < data.length;
             }
-            @SuppressWarnings("unchecked")
+            @Override
+			@SuppressWarnings("unchecked")
             public E next() {
                 return (E) data[idx++];
             }
-            public void remove() {
+            @Override
+			public void remove() {
                 CopyOnWriteSet.this.remove(--idx);
             }
         };
     }
 
-    public int size() {
+    @Override
+	public int size() {
         return data.length;
     }
 
-    public boolean add(E e) {
+    @Override
+	public boolean add(E e) {
         Object[] d = data;
         if (d.length == 0) {
             data = new Object[] {e};
@@ -92,11 +98,13 @@ public class CopyOnWriteSet<E> implements Set<E>, Cloneable {
         data = a;
     }
 
-    public Object[] toArray() {
+    @Override
+	public Object[] toArray() {
         return data.clone();
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public <T> T[] toArray(T[] a) {
         int size = data.length;
         if (a.length < size)
@@ -160,15 +168,18 @@ public class CopyOnWriteSet<E> implements Set<E>, Cloneable {
         }
     }
 
-    public boolean isEmpty() {
+    @Override
+	public boolean isEmpty() {
         return size() == 0;
     }
 
-    public boolean contains(Object o) {
+    @Override
+	public boolean contains(Object o) {
         throw new UnsupportedOperationException();
     }
 
-    public boolean remove(Object o) {
+    @Override
+	public boolean remove(Object o) {
         int index;
         if ((index = indexOf(o, data, data.length)) >= 0) {
             remove(index);
@@ -192,11 +203,13 @@ public class CopyOnWriteSet<E> implements Set<E>, Cloneable {
         return -1;
     }
 
-    public boolean containsAll(Collection<?> c) {
+    @Override
+	public boolean containsAll(Collection<?> c) {
         throw new UnsupportedOperationException();
     }
 
-    public boolean addAll(Collection<? extends E> c) {
+    @Override
+	public boolean addAll(Collection<? extends E> c) {
         Object[] cs = c.toArray();
         if (cs.length == 0)
             return false;
@@ -219,15 +232,18 @@ public class CopyOnWriteSet<E> implements Set<E>, Cloneable {
         return false;
     }
 
-    public boolean retainAll(Collection<?> c) {
+    @Override
+	public boolean retainAll(Collection<?> c) {
         throw new UnsupportedOperationException();
     }
 
-    public boolean removeAll(Collection<?> c) {
+    @Override
+	public boolean removeAll(Collection<?> c) {
         throw new UnsupportedOperationException();
     }
 
-    public void clear() {
+    @Override
+	public void clear() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/OpenHashMap.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/OpenHashMap.java
@@ -119,7 +119,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return this.defRetValue;
     }
 
-    public boolean equals(Object o) {
+    @Override
+	public boolean equals(Object o) {
         if (o == this) {
             return true;
         } else if (!(o instanceof Map)) {
@@ -148,7 +149,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public String toString() {
+    @Override
+	public String toString() {
         StringBuilder s = new StringBuilder();
         Iterator<Map.Entry<K, V>> i = this.fast().iterator();
         int n = this.size();
@@ -229,7 +231,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return (V) oldValue;
     }
 
-    public void putAll(Map<? extends K, ? extends V> m) {
+    @Override
+	public void putAll(Map<? extends K, ? extends V> m) {
         if ((double) this.f <= 0.5D) {
             this.ensureCapacity(m.size());
         } else {
@@ -296,7 +299,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return -1;
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public V put(K k, V v) {
         int pos = this.insert(k, v);
         if (pos < 0) {
@@ -388,7 +392,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public V remove(Object k) {
+    @Override
+	public V remove(Object k) {
         if (k == null) {
             return this.containsNullKey ? this.removeNullEntry() : this.defRetValue;
         } else {
@@ -467,7 +472,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public V get(Object k) {
         if (k == null) {
             return containsNullKey ? (V) value[n] : defRetValue;
@@ -496,7 +502,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public boolean containsKey(Object k) {
+    @Override
+	public boolean containsKey(Object k) {
         if (k == null) {
             return this.containsNullKey;
         } else {
@@ -519,7 +526,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public boolean containsValue(Object v) {
+    @Override
+	public boolean containsValue(Object v) {
         Object[] value = this.value;
         Object[] key = this.key;
         if (containsNullKey && (value[n] == null && v == null) || value[n].equals(v)) {
@@ -533,7 +541,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return false;
     }
 
-    public void clear() {
+    @Override
+	public void clear() {
         if (size != 0) {
             size = 0;
             containsNullKey = false;
@@ -543,11 +552,13 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public int size() {
+    @Override
+	public int size() {
         return this.size;
     }
 
-    public boolean isEmpty() {
+    @Override
+	public boolean isEmpty() {
         return this.size == 0;
     }
 
@@ -595,7 +606,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public K firstKey() {
         if (size == 0) {
             throw new NoSuchElementException();
@@ -604,7 +616,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public K lastKey() {
         if (size == 0) {
             throw new NoSuchElementException();
@@ -613,26 +626,31 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         }
     }
 
-    public Comparator<? super K> comparator() {
+    @Override
+	public Comparator<? super K> comparator() {
         return null;
     }
 
-    public SortedMap<K, V> tailMap(K from) {
+    @Override
+	public SortedMap<K, V> tailMap(K from) {
         throw new UnsupportedOperationException();
     }
 
-    public SortedMap<K, V> headMap(K to) {
+    @Override
+	public SortedMap<K, V> headMap(K to) {
         throw new UnsupportedOperationException();
     }
 
-    public SortedMap<K, V> subMap(K from, K to) {
+    @Override
+	public SortedMap<K, V> subMap(K from, K to) {
         throw new UnsupportedOperationException();
     }
 
     public Iterable<Map.Entry<K, V>> fast() {
         if (fast == null) {
             fast = new Iterable<Entry<K, V>>() {
-                public Iterator<Entry<K, V>> iterator() {
+                @Override
+				public Iterator<Entry<K, V>> iterator() {
                     return new FastEntryIterator();
                 }
             };
@@ -641,7 +659,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return fast;
     }
 
-    public SortedSet<Map.Entry<K, V>> entrySet() {
+    @Override
+	public SortedSet<Map.Entry<K, V>> entrySet() {
         if (entries == null) {
             entries = new MapEntrySet();
         }
@@ -649,7 +668,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return this.entries;
     }
 
-    public SortedSet<K> keySet() {
+    @Override
+	public SortedSet<K> keySet() {
         if (keys == null) {
             keys = new KeySet();
         }
@@ -657,22 +677,27 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return keys;
     }
 
-    public Collection<V> values() {
+    @Override
+	public Collection<V> values() {
         if (values == null) {
             values = new AbstractObjectCollection<V>() {
-                public Iterator<V> iterator() {
+                @Override
+				public Iterator<V> iterator() {
                     return new ValueIterator();
                 }
 
-                public int size() {
+                @Override
+				public int size() {
                     return size;
                 }
 
-                public boolean contains(Object v) {
+                @Override
+				public boolean contains(Object v) {
                     return containsValue(v);
                 }
 
-                public void clear() {
+                @Override
+				public void clear() {
                     OpenHashMap.this.clear();
                 }
             };
@@ -801,7 +826,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         this.value = newValue;
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
+	@SuppressWarnings("unchecked")
     public OpenHashMap<K, V> clone() {
         OpenHashMap<K, V> c;
         try {
@@ -821,7 +847,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         return c;
     }
 
-    public int hashCode() {
+    @Override
+	public int hashCode() {
         int h = 0;
         for( int j = realSize(), i = 0, t = 0; j-- != 0; ) {
             while (key[i] == null) {
@@ -912,7 +939,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             super();
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public V next() {
             return (V) value[this.nextEntry()];
         }
@@ -922,29 +950,35 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         private KeySet() {
         }
 
-        public Iterator<K> iterator() {
+        @Override
+		public Iterator<K> iterator() {
             return new KeyIterator();
         }
 
-        public int size() {
+        @Override
+		public int size() {
             return size;
         }
 
-        public boolean contains(Object k) {
+        @Override
+		public boolean contains(Object k) {
             return containsKey(k);
         }
 
-        public boolean remove(Object k) {
+        @Override
+		public boolean remove(Object k) {
             int oldSize = size;
             OpenHashMap.this.remove(k);
             return size != oldSize;
         }
 
-        public void clear() {
+        @Override
+		public void clear() {
             OpenHashMap.this.clear();
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public K first() {
             if (size == 0) {
                 throw new NoSuchElementException();
@@ -953,7 +987,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public K last() {
             if (size == 0) {
                 throw new NoSuchElementException();
@@ -962,19 +997,23 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public Comparator<? super K> comparator() {
+        @Override
+		public Comparator<? super K> comparator() {
             return null;
         }
 
-        public final SortedSet<K> tailSet(K from) {
+        @Override
+		public final SortedSet<K> tailSet(K from) {
             throw new UnsupportedOperationException();
         }
 
-        public final SortedSet<K> headSet(K to) {
+        @Override
+		public final SortedSet<K> headSet(K to) {
             throw new UnsupportedOperationException();
         }
 
-        public final SortedSet<K> subSet(K from, K to) {
+        @Override
+		public final SortedSet<K> subSet(K from, K to) {
             throw new UnsupportedOperationException();
         }
     }
@@ -984,7 +1023,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             super();
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public K next() {
             return (K) key[this.nextEntry()];
         }
@@ -994,27 +1034,33 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         private MapEntrySet() {
         }
 
-        public EntryIterator iterator() {
+        @Override
+		public EntryIterator iterator() {
             return new EntryIterator();
         }
 
-        public Comparator<? super Entry<K, V>> comparator() {
+        @Override
+		public Comparator<? super Entry<K, V>> comparator() {
             return null;
         }
 
-        public SortedSet<Entry<K, V>> subSet(Entry<K, V> fromElement, Entry<K, V> toElement) {
+        @Override
+		public SortedSet<Entry<K, V>> subSet(Entry<K, V> fromElement, Entry<K, V> toElement) {
             throw new UnsupportedOperationException();
         }
 
-        public SortedSet<Entry<K, V>> headSet(Entry<K, V> toElement) {
+        @Override
+		public SortedSet<Entry<K, V>> headSet(Entry<K, V> toElement) {
             throw new UnsupportedOperationException();
         }
 
-        public SortedSet<Entry<K, V>> tailSet(Entry<K, V> fromElement) {
+        @Override
+		public SortedSet<Entry<K, V>> tailSet(Entry<K, V> fromElement) {
             throw new UnsupportedOperationException();
         }
 
-        public Entry<K, V> first() {
+        @Override
+		public Entry<K, V> first() {
             if (size == 0) {
                 throw new NoSuchElementException();
             } else {
@@ -1022,7 +1068,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public Entry<K, V> last() {
+        @Override
+		public Entry<K, V> last() {
             if (size == 0) {
                 throw new NoSuchElementException();
             } else {
@@ -1030,7 +1077,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public boolean contains(Object o) {
+        @Override
+		public boolean contains(Object o) {
             if (!(o instanceof java.util.Map.Entry)) {
                 return false;
             } else {
@@ -1071,7 +1119,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public boolean remove(Object o) {
+        @Override
+		public boolean remove(Object o) {
             if (!(o instanceof java.util.Map.Entry)) {
                 return false;
             } else {
@@ -1134,11 +1183,13 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public int size() {
+        @Override
+		public int size() {
             return size;
         }
 
-        public void clear() {
+        @Override
+		public void clear() {
             OpenHashMap.this.clear();
         }
     }
@@ -1151,7 +1202,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             this.entry = new MapEntry();
         }
 
-        public MapEntry next() {
+        @Override
+		public MapEntry next() {
             this.entry.index = this.nextEntry();
             return this.entry;
         }
@@ -1164,18 +1216,21 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             super();
         }
 
-        public MapEntry next() {
+        @Override
+		public MapEntry next() {
             return this.entry = new MapEntry(this.nextEntry());
         }
 
-        public void remove() {
+        @Override
+		public void remove() {
             super.remove();
             this.entry.index = -1;
         }
     }
 
     public static abstract class AbstractObjectSet<K> extends AbstractObjectCollection<K> implements Cloneable {
-        public boolean equals(Object o) {
+        @Override
+		public boolean equals(Object o) {
             if (o == this) {
                 return true;
             } else if (!(o instanceof Set)) {
@@ -1186,7 +1241,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public int hashCode() {
+        @Override
+		public int hashCode() {
             int h = 0;
             int n = this.size();
 
@@ -1324,24 +1380,28 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         MapEntry() {
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public K getKey() {
             return (K) key[this.index];
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public V getValue() {
             return (V) value[this.index];
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public V setValue(V v) {
             Object oldValue = value[this.index];
             value[this.index] = v;
             return (V) oldValue;
         }
 
-        public boolean equals(Object o) {
+        @Override
+		public boolean equals(Object o) {
             if (!(o instanceof Entry)) {
                 return false;
             } else {
@@ -1366,13 +1426,15 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             }
         }
 
-        public int hashCode() {
+        @Override
+		public int hashCode() {
             return (key[this.index] == null ? 0 :
                     key[this.index].hashCode()) ^ (value[this.index] == null ? 0 :
                     value[this.index].hashCode());
         }
 
-        public String toString() {
+        @Override
+		public String toString() {
             return key[this.index] + "=>" + value[this.index];
         }
     }
@@ -1382,13 +1444,15 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
         protected AbstractObjectCollection() {
         }
 
-        public Object[] toArray() {
+        @Override
+		public Object[] toArray() {
             Object[] a = new Object[this.size()];
             unwrap(this.iterator(), a);
             return a;
         }
 
-        @SuppressWarnings("unchecked")
+        @Override
+		@SuppressWarnings("unchecked")
         public <T> T[] toArray(T[] a) {
             if (a.length < this.size()) {
                 a = (T[]) Array.newInstance(a.getClass().getComponentType(), this.size());
@@ -1397,7 +1461,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             return a;
         }
 
-        public boolean addAll(Collection<? extends K> c) {
+        @Override
+		public boolean addAll(Collection<? extends K> c) {
             boolean retVal = false;
             Iterator<? extends K> i = c.iterator();
             int n = c.size();
@@ -1411,11 +1476,13 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             return retVal;
         }
 
-        public boolean add(K k) {
+        @Override
+		public boolean add(K k) {
             throw new UnsupportedOperationException();
         }
 
-        public boolean containsAll(Collection<?> c) {
+        @Override
+		public boolean containsAll(Collection<?> c) {
             int n = c.size();
             Iterator<?> i = c.iterator();
 
@@ -1428,7 +1495,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             return false;
         }
 
-        public boolean retainAll(Collection<?> c) {
+        @Override
+		public boolean retainAll(Collection<?> c) {
             boolean retVal = false;
             int n = this.size();
             Iterator<K> i = this.iterator();
@@ -1443,7 +1511,8 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             return retVal;
         }
 
-        public boolean removeAll(Collection<?> c) {
+        @Override
+		public boolean removeAll(Collection<?> c) {
             boolean retVal = false;
             int n = c.size();
             Iterator<?> i = c.iterator();
@@ -1457,11 +1526,13 @@ public class OpenHashMap<K, V> implements Serializable, Cloneable, SortedMap<K, 
             return retVal;
         }
 
-        public boolean isEmpty() {
+        @Override
+		public boolean isEmpty() {
             return this.size() == 0;
         }
 
-        public String toString() {
+        @Override
+		public String toString() {
             StringBuilder s = new StringBuilder();
             Iterator<K> i = this.iterator();
             int n = this.size();

--- a/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
+++ b/bundles/org.eclipse.osgi/felix/src/org/apache/felix/resolver/util/ShadowList.java
@@ -52,7 +52,8 @@ public class ShadowList extends CandidateSelector
         m_original = new ArrayList<Capability>(original);
     }
 
-    public ShadowList copy() {
+    @Override
+	public ShadowList copy() {
         return new ShadowList(this, m_original);
     }
 

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/ResolverTest.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/ResolverTest.java
@@ -1610,19 +1610,23 @@ public class ResolverTest
             this.provider = provider;
         }
 
-        public Capability getCapability() {
+        @Override
+		public Capability getCapability() {
             return capability;
         }
 
-        public Requirement getRequirement() {
+        @Override
+		public Requirement getRequirement() {
             return requirement;
         }
 
-        public Resource getRequirer() {
+        @Override
+		public Resource getRequirer() {
             return requirer;
         }
 
-        public Resource getProvider() {
+        @Override
+		public Resource getProvider() {
             return provider;
         }
     }
@@ -1641,7 +1645,8 @@ public class ResolverTest
             this.resourceCapabilities = resourceCapabilities;
         }
 
-        public List<Capability> getResourceCapabilities(String namespace) {
+        @Override
+		public List<Capability> getResourceCapabilities(String namespace) {
             if (resourceCapabilities == null) {
                 resourceCapabilities = new ArrayList<Capability>();
                 for (Wire wire : invertedWires.get(resource)) {
@@ -1662,7 +1667,8 @@ public class ResolverTest
             return resourceCapabilities;
         }
 
-        public List<Requirement> getResourceRequirements(String namespace) {
+        @Override
+		public List<Requirement> getResourceRequirements(String namespace) {
             if (resourceRequirements == null) {
                 resourceRequirements = new ArrayList<Requirement>();
                 for (Wire wire : wires.get(resource)) {
@@ -1683,7 +1689,8 @@ public class ResolverTest
             return resourceRequirements;
         }
 
-        public List<Wire> getProvidedResourceWires(String namespace) {
+        @Override
+		public List<Wire> getProvidedResourceWires(String namespace) {
             List<Wire> providedWires = invertedWires.get(resource);
             if (namespace != null) {
                 List<Wire> wires = new ArrayList<Wire>();
@@ -1697,7 +1704,8 @@ public class ResolverTest
             return providedWires;
         }
 
-        public List<Wire> getRequiredResourceWires(String namespace) {
+        @Override
+		public List<Wire> getRequiredResourceWires(String namespace) {
             List<Wire> requiredWires = wires.get(resource);
             if (namespace != null) {
                 List<Wire> wires = new ArrayList<Wire>();
@@ -1711,7 +1719,8 @@ public class ResolverTest
             return requiredWires;
         }
 
-        public Resource getResource() {
+        @Override
+		public Resource getResource() {
             return resource;
         }
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/BundleCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/BundleCapability.java
@@ -40,7 +40,8 @@ public class BundleCapability implements Capability
         m_attrs.put(BundleNamespace.BUNDLE_NAMESPACE.intern(), name);
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return BundleNamespace.BUNDLE_NAMESPACE.intern();
     }
@@ -50,7 +51,8 @@ public class BundleCapability implements Capability
         m_dirs.put(name.intern(), value);
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
@@ -60,12 +62,14 @@ public class BundleCapability implements Capability
         m_attrs.put(name.intern(), value);
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/BundleRequirement.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/BundleRequirement.java
@@ -42,22 +42,26 @@ public class BundleRequirement implements Requirement
         m_attrs = new HashMap<String, Object>();
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return BundleNamespace.BUNDLE_NAMESPACE.intern();
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/CandidateComparator.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/CandidateComparator.java
@@ -30,7 +30,8 @@ import org.osgi.resource.Capability;
 
 public class CandidateComparator implements Comparator<Capability>
 {
-    public int compare(Capability cap1, Capability cap2)
+    @Override
+	public int compare(Capability cap1, Capability cap2)
     {
         int c = 0;
         // Always prefer system bundle

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/GenericCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/GenericCapability.java
@@ -39,7 +39,8 @@ public class GenericCapability implements Capability
         m_attrs = new HashMap<String, Object>();
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return m_namespace;
     }
@@ -49,7 +50,8 @@ public class GenericCapability implements Capability
         m_dirs.put(name.intern(), value);
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
@@ -59,12 +61,14 @@ public class GenericCapability implements Capability
         m_attrs.put(name.intern(), value);
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/GenericRequirement.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/GenericRequirement.java
@@ -53,7 +53,8 @@ public class GenericRequirement implements Requirement
         }
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return m_namespace;
     }
@@ -63,7 +64,8 @@ public class GenericRequirement implements Requirement
         m_dirs.put(name.intern(), value);
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
@@ -73,12 +75,14 @@ public class GenericRequirement implements Requirement
         m_attrs.put(name.intern(), value);
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/IdentityCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/IdentityCapability.java
@@ -42,22 +42,26 @@ public class IdentityCapability implements Capability
         m_attrs.put(IdentityNamespace.CAPABILITY_VERSION_ATTRIBUTE, v);
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return IdentityNamespace.IDENTITY_NAMESPACE;
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/IterativeResolver.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/IterativeResolver.java
@@ -43,7 +43,8 @@ public class IterativeResolver implements Resolver {
         this.resolver = resolver;
     }
 
-    public Map<Resource, List<Wire>> resolve(final ResolveContext context) throws ResolutionException {
+    @Override
+	public Map<Resource, List<Wire>> resolve(final ResolveContext context) throws ResolutionException {
 
         final Map<Resource, List<Wire>> wires = new HashMap<Resource, List<Wire>>();
         final Map<Resource, List<Wire>> invertedWires = new HashMap<Resource, List<Wire>>();
@@ -104,7 +105,7 @@ public class IterativeResolver implements Resolver {
         return wires;
     }
 
-    private class SimpleWiring implements Wiring {
+    private static class SimpleWiring implements Wiring {
         final Resource resource;
         final Map<Resource, List<Wire>> wires;
         final Map<Resource, List<Wire>> invertedWires;
@@ -117,7 +118,8 @@ public class IterativeResolver implements Resolver {
             this.invertedWires = invertedWires;
         }
 
-        public List<Capability> getResourceCapabilities(String namespace) {
+        @Override
+		public List<Capability> getResourceCapabilities(String namespace) {
             if (resourceCapabilities == null) {
                 resourceCapabilities = new ArrayList<Capability>();
                 for (Wire wire : invertedWires.get(resource)) {
@@ -138,7 +140,8 @@ public class IterativeResolver implements Resolver {
             return resourceCapabilities;
         }
 
-        public List<Requirement> getResourceRequirements(String namespace) {
+        @Override
+		public List<Requirement> getResourceRequirements(String namespace) {
             if (resourceRequirements == null) {
                 resourceRequirements = new ArrayList<Requirement>();
                 for (Wire wire : wires.get(resource)) {
@@ -159,7 +162,8 @@ public class IterativeResolver implements Resolver {
             return resourceRequirements;
         }
 
-        public List<Wire> getProvidedResourceWires(String namespace) {
+        @Override
+		public List<Wire> getProvidedResourceWires(String namespace) {
             List<Wire> providedWires = invertedWires.get(resource);
             if (namespace != null) {
                 List<Wire> wires = new ArrayList<Wire>();
@@ -173,7 +177,8 @@ public class IterativeResolver implements Resolver {
             return providedWires;
         }
 
-        public List<Wire> getRequiredResourceWires(String namespace) {
+        @Override
+		public List<Wire> getRequiredResourceWires(String namespace) {
             List<Wire> requiredWires = wires.get(resource);
             if (namespace != null) {
                 List<Wire> wires = new ArrayList<Wire>();
@@ -187,12 +192,14 @@ public class IterativeResolver implements Resolver {
             return requiredWires;
         }
 
-        public Resource getResource() {
+        @Override
+		public Resource getResource() {
             return resource;
         }
     }
 
-    public Map<Resource, List<Wire>> resolveDynamic(ResolveContext context,
+    @Override
+	public Map<Resource, List<Wire>> resolveDynamic(ResolveContext context,
         Wiring hostWiring, Requirement dynamicRequirement) throws ResolutionException
     {
         throw new UnsupportedOperationException();

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/PackageCapability.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/PackageCapability.java
@@ -39,7 +39,8 @@ public class PackageCapability implements Capability
         m_attrs.put(PackageNamespace.PACKAGE_NAMESPACE, name);
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return PackageNamespace.PACKAGE_NAMESPACE;
     }
@@ -49,7 +50,8 @@ public class PackageCapability implements Capability
         m_dirs.put(name, value);
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
@@ -59,12 +61,14 @@ public class PackageCapability implements Capability
         m_attrs.put(name, value);
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/PackageRequirement.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/PackageRequirement.java
@@ -41,22 +41,26 @@ public class PackageRequirement implements Requirement
         m_attrs = new HashMap<String, Object>();
     }
 
-    public String getNamespace()
+    @Override
+	public String getNamespace()
     {
         return PackageNamespace.PACKAGE_NAMESPACE;
     }
 
-    public Map<String, String> getDirectives()
+    @Override
+	public Map<String, String> getDirectives()
     {
         return m_dirs;
     }
 
-    public Map<String, Object> getAttributes()
+    @Override
+	public Map<String, Object> getAttributes()
     {
         return m_attrs;
     }
 
-    public Resource getResource()
+    @Override
+	public Resource getResource()
     {
         return m_resource;
     }

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/ResolveContextImpl.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/ResolveContextImpl.java
@@ -107,7 +107,8 @@ public class ResolveContextImpl extends ResolveContext
             return Collections.emptyList();
         }
 
-        public List<Wire> getSubstitutionWires(Wiring wiring)
+        @Override
+		public List<Wire> getSubstitutionWires(Wiring wiring)
         {
             List<Wire> result = m_substitutions.get(wiring);
             return result == null ? Collections.<Wire> emptyList() : result;

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/ResourceImpl.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/ResourceImpl.java
@@ -53,7 +53,8 @@ public class ResourceImpl implements Resource
         m_caps.add(cap);
     }
 
-    public List<Capability> getCapabilities(String namespace)
+    @Override
+	public List<Capability> getCapabilities(String namespace)
     {
         List<Capability> result = m_caps;
         if (namespace != null)
@@ -75,7 +76,8 @@ public class ResourceImpl implements Resource
         m_reqs.add(req);
     }
 
-    public List<Requirement> getRequirements(String namespace)
+    @Override
+	public List<Requirement> getRequirements(String namespace)
     {
         List<Requirement> result = m_reqs;
         if (namespace != null)

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/SimpleFilter.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/resolver/test/util/SimpleFilter.java
@@ -64,7 +64,8 @@ public class SimpleFilter
         return m_op;
     }
 
-    public String toString()
+    @Override
+	public String toString()
     {
         String s = null;
         switch (m_op)

--- a/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/utils/version/VersionRange.java
+++ b/bundles/org.eclipse.osgi/felix/src_test/org/apache/felix/utils/version/VersionRange.java
@@ -349,7 +349,8 @@ public class VersionRange implements Serializable
     }
 
 
-    public int hashCode()
+    @Override
+	public int hashCode()
     {
         final int prime = 31;
         int result = 1;
@@ -361,7 +362,8 @@ public class VersionRange implements Serializable
     }
 
 
-    public boolean equals( Object obj )
+    @Override
+	public boolean equals( Object obj )
     {
         if ( this == obj )
             return true;
@@ -392,7 +394,8 @@ public class VersionRange implements Serializable
     }
 
 
-    public String toString()
+    @Override
+	public String toString()
     {
         if ( ANY_VERSION.equals( this ) )
         {

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Configurable.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Configurable.java
@@ -28,6 +28,7 @@ package org.osgi.framework;
  * @deprecated As of 1.2. Please use Configuration Admin service.
  * @author $Id$
  */
+@Deprecated
 public interface Configurable {
 	/**
 	 * Returns this service's configuration object.
@@ -46,5 +47,6 @@ public interface Configurable {
 	 *         permission and the Java Runtime Environment supports permissions.
 	 * @deprecated As of 1.2. Please use Configuration Admin service.
 	 */
+	@Deprecated
 	public Object getConfigurationObject();
 }

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Constants.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/Constants.java
@@ -130,6 +130,7 @@ public interface Constants {
 	 * 
 	 * @deprecated As of 1.2.
 	 */
+	@Deprecated
 	String	EXPORT_SERVICE							= "Export-Service";
 
 	/**
@@ -163,6 +164,7 @@ public interface Constants {
 	 * 
 	 * @deprecated As of 1.2.
 	 */
+	@Deprecated
 	String	IMPORT_SERVICE							= "Import-Service";
 
 	/**
@@ -248,6 +250,7 @@ public interface Constants {
 	 * @deprecated As of 1.3. This has been replaced by
 	 *             {@link #VERSION_ATTRIBUTE}.
 	 */
+	@Deprecated
 	String	PACKAGE_SPECIFICATION_VERSION			= "specification-version";
 
 	/**
@@ -327,6 +330,7 @@ public interface Constants {
 	 * @since 1.2
 	 * @deprecated As of 1.6. Replaced by the {@code osgi.ee} capability.
 	 */
+	@Deprecated
 	String	BUNDLE_REQUIREDEXECUTIONENVIRONMENT		= "Bundle-RequiredExecutionEnvironment";
 
 	/**
@@ -849,6 +853,7 @@ public interface Constants {
 	 * @since 1.3
 	 * @deprecated As of 1.9.
 	 */
+	@Deprecated
 	String	EXTENSION_BOOTCLASSPATH					= "bootclasspath";
 
 	/**
@@ -958,6 +963,7 @@ public interface Constants {
 	 * @since 1.2
 	 * @deprecated As of 1.6. Replaced by the {@code osgi.ee} capability.
 	 */
+	@Deprecated
 	String	FRAMEWORK_EXECUTIONENVIRONMENT			= "org.osgi.framework.executionenvironment";
 
 	/**
@@ -1036,6 +1042,7 @@ public interface Constants {
 	 * @since 1.3
 	 * @deprecated As of 1.10.
 	 */
+	@Deprecated
 	String	SUPPORTS_BOOTCLASSPATH_EXTENSION		= "org.osgi.supports.bootclasspath.extension";
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/FrameworkEvent.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/FrameworkEvent.java
@@ -156,6 +156,7 @@ public class FrameworkEvent extends EventObject {
 	 * @since 1.5
 	 * @deprecated As of 1.10.
 	 */
+	@Deprecated
 	public final static int	STOPPED_BOOTCLASSPATH_MODIFIED	= 0x00000100;
 
 	/**
@@ -191,6 +192,7 @@ public class FrameworkEvent extends EventObject {
 	 *             the other constructor with the System Bundle as the event
 	 *             source.
 	 */
+	@Deprecated
 	public FrameworkEvent(int type, Object source) {
 		super(source);
 		this.type = type;

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/PackagePermission.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/PackagePermission.java
@@ -66,6 +66,7 @@ public final class PackagePermission extends BasicPermission {
 	 * 
 	 * @deprecated As of 1.5. Use {@code exportonly} instead.
 	 */
+	@Deprecated
 	public final static String						EXPORT				= "export";
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/hooks/service/EventHook.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/hooks/service/EventHook.java
@@ -32,6 +32,7 @@ import org.osgi.framework.ServiceEvent;
  * @deprecated As of 1.1. Replaced by {@link EventListenerHook}.
  * @author $Id$
  */
+@Deprecated
 @ConsumerType
 public interface EventHook {
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/namespace/HostNamespace.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/framework/namespace/HostNamespace.java
@@ -153,6 +153,7 @@ public final class HostNamespace extends AbstractWiringNamespace {
 	 * @see #REQUIREMENT_EXTENSION_DIRECTIVE
 	 * @deprecated As of 1.2.
 	 */
+	@Deprecated
 	public final static String	EXTENSION_BOOTCLASSPATH						= "bootclasspath";
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/condpermadmin/ConditionalPermissionAdmin.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/condpermadmin/ConditionalPermissionAdmin.java
@@ -60,6 +60,7 @@ public interface ConditionalPermissionAdmin {
 	 * @deprecated As of 1.1. Use {@link #newConditionalPermissionUpdate()}
 	 *             instead.
 	 */
+	@Deprecated
 	ConditionalPermissionInfo addConditionalPermissionInfo(ConditionInfo[] conditions, PermissionInfo[] permissions);
 
 	/**
@@ -96,6 +97,7 @@ public interface ConditionalPermissionAdmin {
 	 * @deprecated As of 1.1. Use {@link #newConditionalPermissionUpdate()}
 	 *             instead.
 	 */
+	@Deprecated
 	ConditionalPermissionInfo setConditionalPermissionInfo(String name, ConditionInfo[] conditions, PermissionInfo[] permissions);
 
 	/**
@@ -115,6 +117,7 @@ public interface ConditionalPermissionAdmin {
 	 * @deprecated As of 1.1. Use {@link #newConditionalPermissionUpdate()}
 	 *             instead.
 	 */
+	@Deprecated
 	Enumeration<ConditionalPermissionInfo> getConditionalPermissionInfos();
 
 	/**
@@ -127,6 +130,7 @@ public interface ConditionalPermissionAdmin {
 	 * @deprecated As of 1.1. Use {@link #newConditionalPermissionUpdate()}
 	 *             instead.
 	 */
+	@Deprecated
 	ConditionalPermissionInfo getConditionalPermissionInfo(String name);
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/condpermadmin/ConditionalPermissionInfo.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/condpermadmin/ConditionalPermissionInfo.java
@@ -89,6 +89,7 @@ public interface ConditionalPermissionInfo {
 	 *             {@link ConditionalPermissionAdmin#newConditionalPermissionUpdate()}
 	 *             instead to manage the Conditional Permissions.
 	 */
+	@Deprecated
 	void delete();
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/ExportedPackage.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/ExportedPackage.java
@@ -47,6 +47,7 @@ import org.osgi.framework.Version;
  *             <code>org.osgi.framework.wiring</code> package.
  * @author $Id$
  */
+@Deprecated
 public interface ExportedPackage {
 	/**
 	 * Returns the name of the package associated with this exported package.
@@ -87,6 +88,7 @@ public interface ExportedPackage {
 	 *         version information is available.
 	 * @deprecated As of 1.2. Replaced by {@link #getVersion()}.
 	 */
+	@Deprecated
 	public String getSpecificationVersion();
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/PackageAdmin.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/PackageAdmin.java
@@ -35,6 +35,7 @@ import org.osgi.framework.Bundle;
  * @see org.osgi.service.packageadmin.ExportedPackage
  * @see org.osgi.service.packageadmin.RequiredBundle
  */
+@Deprecated
 public interface PackageAdmin {
 	/**
 	 * Gets the exported packages for the specified bundle.
@@ -55,6 +56,7 @@ public interface PackageAdmin {
 	 *         {@code PackageAdmin} service.
 	 * @deprecated
 	 */
+	@Deprecated
 	public ExportedPackage[] getExportedPackages(Bundle bundle);
 
 	/**
@@ -67,6 +69,7 @@ public interface PackageAdmin {
 	 * @since 1.2
 	 * @deprecated
 	 */
+	@Deprecated
 	public ExportedPackage[] getExportedPackages(String name);
 
 	/**
@@ -83,6 +86,7 @@ public interface PackageAdmin {
 	 * @see #getExportedPackages(String)
 	 * @deprecated
 	 */
+	@Deprecated
 	public ExportedPackage getExportedPackage(String name);
 
 	/**
@@ -191,6 +195,7 @@ public interface PackageAdmin {
 	 * @since 1.2
 	 * @deprecated
 	 */
+	@Deprecated
 	public RequiredBundle[] getRequiredBundles(String symbolicName);
 
 	/**

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/RequiredBundle.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/packageadmin/RequiredBundle.java
@@ -48,6 +48,7 @@ import org.osgi.framework.Version;
  *             <code>org.osgi.framework.wiring</code> package.
  * @author $Id$
  */
+@Deprecated
 public interface RequiredBundle {
 	/**
 	 * Returns the symbolic name of this required bundle.

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/startlevel/StartLevel.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/startlevel/StartLevel.java
@@ -72,6 +72,7 @@ import org.osgi.framework.Bundle;
  * @deprecated This service has been replaced by the
  *             <code>org.osgi.framework.startlevel</code> package.
  */
+@Deprecated
 public interface StartLevel {
 	/**
 	 * Return the active start level value of the Framework.

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/url/AbstractURLStreamHandlerService.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/url/AbstractURLStreamHandlerService.java
@@ -140,6 +140,7 @@ public abstract class AbstractURLStreamHandlerService extends URLStreamHandler i
 	 * @deprecated This method is only for compatibility with handlers written
 	 *             for JDK 1.1.
 	 */
+	@Deprecated
 	@Override
 	protected void setURL(URL u, String proto, String host, int port, String file, String ref) {
 		realHandler.setURL(u, proto, host, port, file, ref);

--- a/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/url/URLStreamHandlerSetter.java
+++ b/bundles/org.eclipse.osgi/osgi/src/org/osgi/service/url/URLStreamHandlerSetter.java
@@ -42,6 +42,7 @@ public interface URLStreamHandlerSetter {
 	 * @deprecated This method is only for compatibility with handlers written
 	 *             for JDK 1.1.
 	 */
+	@Deprecated
 	@SuppressWarnings("javadoc")
 	public void setURL(URL u, String protocol, String host, int port, String file, String ref);
 

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/eventmgr/EventListeners.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/eventmgr/EventListeners.java
@@ -28,6 +28,7 @@ import java.util.Set;
  * @deprecated As of 3.5. Replaced by CopyOnWriteIdentityMap.
  * @noextend This class is not intended to be subclassed by clients.
  */
+@Deprecated
 public class EventListeners<K, V> {
 	private final CopyOnWriteIdentityMap<K, V> list = new CopyOnWriteIdentityMap<>();
 

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/eventmgr/ListenerQueue.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/eventmgr/ListenerQueue.java
@@ -83,6 +83,7 @@ public class ListenerQueue<K, V, E> {
 	 * @throws IllegalStateException If called after one of the dispatch methods has been called.
 	 * @deprecated As of 3.5. Replaced by {@link #queueListeners(Set, EventDispatcher)}.
 	 */
+	@Deprecated
 	public void queueListeners(EventListeners<K, V> listeners, EventDispatcher<K, V, E> dispatcher) {
 		queueListeners(listeners.entrySet(), dispatcher);
 	}

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/internal/reliablefile/ReliableFile.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/internal/reliablefile/ReliableFile.java
@@ -140,7 +140,7 @@ public class ReliableFile {
 	}
 
 	/** File object for original reference file */
-	private File referenceFile;
+	private final File referenceFile;
 
 	/** List of checksum file objects: File => specific ReliableFile generation */
 	private static Hashtable<File, CacheInfo> cacheFiles = new Hashtable<>(20);
@@ -894,7 +894,7 @@ public class ReliableFile {
 		return buffer;
 	}
 
-	private class CacheInfo {
+	private static class CacheInfo {
 		int filetype;
 		Checksum checksum;
 		long timeStamp;

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/internal/reliablefile/ReliableFileInputStream.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/framework/internal/reliablefile/ReliableFileInputStream.java
@@ -33,7 +33,7 @@ public class ReliableFileInputStream extends FilterInputStream {
 	/**
 	 * size of crc and signature
 	 */
-	private int sigSize;
+	private final int sigSize;
 
 	/**
 	 * current position reading from file

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/Locker_JavaIo.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/internal/location/Locker_JavaIo.java
@@ -19,7 +19,7 @@ import java.io.*;
  * Internal class.
  */
 public class Locker_JavaIo implements Locker {
-	private File lockFile;
+	private final File lockFile;
 	private RandomAccessFile lockRAF;
 
 	public Locker_JavaIo(File lockFile) {

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/service/datalocation/Location.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/service/datalocation/Location.java
@@ -204,6 +204,7 @@ public interface Location {
 	 * @throws IllegalStateException if the location's value is already set
 	 * @deprecated use {@link #set(URL, boolean)} instead.
 	 */
+	@Deprecated
 	public boolean setURL(URL value, boolean lock) throws IllegalStateException;
 
 	/**

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/service/environment/Constants.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/service/environment/Constants.java
@@ -154,6 +154,7 @@ public interface Constants {
 	 * @deprecated use <code>ARCH_X86_64</code> instead. Note the values
 	 * has been changed to be the value of the <code>ARCH_X86_64</code> constant.
 	 */
+	@Deprecated
 	public static final String ARCH_AMD64 = ARCH_X86_64;
 
 	/**

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/ManagedOutputStream.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/ManagedOutputStream.java
@@ -29,9 +29,9 @@ import java.io.*;
 public final class ManagedOutputStream extends FilterOutputStream {
 	static final int ST_OPEN = 0;
 	static final int ST_CLOSED = 1;
-	private String target;
-	private StorageManager manager;
-	private File outputFile;
+	private final String target;
+	private final StorageManager manager;
+	private final File outputFile;
 	private int state;
 	private ManagedOutputStream[] streamSet = null;
 

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/StorageManager.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/StorageManager.java
@@ -110,7 +110,7 @@ public final class StorageManager {
 	private final boolean openCleanup = Boolean.valueOf(System.getProperty("osgi.embedded.cleanupOnOpen")).booleanValue(); //$NON-NLS-1$
 	private final boolean saveCleanup = Boolean.valueOf(System.getProperty("osgi.embedded.cleanupOnSave")).booleanValue(); //$NON-NLS-1$
 
-	private class Entry {
+	private static class Entry {
 		int readId;
 		int writeId;
 		int fileType;

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,20 @@
 
   <build>
     <plugins>
+
+
+		<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-cleancode-plugin</artifactId>
+				<configuration>
+					<debug>true</debug>
+				</configuration>
+                </plugin>
+
+
+
+
+	    
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-source-plugin</artifactId>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

