### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.servlet

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/HttpServiceServlet.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/HttpServiceServlet.java
@@ -23,7 +23,7 @@ import org.eclipse.equinox.http.servlet.internal.servlet.ProxyServlet;
  * an OSGi Http Service implementation. This class is not meant for extending or
  * even using directly and is purely meant for registering in a servlet
  * container.
- * 
+ *
  * @noextend This class is not intended to be subclassed by clients.
  */
 public class HttpServiceServlet extends ProxyServlet {

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/context/ContextPathCustomizer.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/context/ContextPathCustomizer.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Liferay, Inc. - initial API and implementation and/or initial 
+ *    Liferay, Inc. - initial API and implementation and/or initial
  *                    documentation
  ******************************************************************************/
 
@@ -41,7 +41,7 @@ import org.osgi.service.http.context.ServletContextHelper;
  * pioneering adopters on the understanding that any code that uses this SPI
  * will almost certainly be broken (repeatedly) as the SPI evolves.
  * </p>
- * 
+ *
  * @since 1.2
  */
 public abstract class ContextPathCustomizer {
@@ -51,7 +51,7 @@ public abstract class ContextPathCustomizer {
 	 * service. This method is only called if the supplied whiteboard service does
 	 * not provide the &quot;osgi.http.whiteboard.context.select&quot; service
 	 * property.
-	 * 
+	 *
 	 * @return a service filter that is used to select the default
 	 *         SErvletContextHelper for the specified whiteboard service.
 	 */
@@ -63,7 +63,7 @@ public abstract class ContextPathCustomizer {
 	 * Returns a prefix that is prepended to the context path value specified by the
 	 * supplied helper's &quot;osgi.http.whiteboard.context.path&quot; service
 	 * property.
-	 * 
+	 *
 	 * @param helper the helper for which the context path will be prepended to
 	 * @return the prefix to prepend to the context path
 	 */

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ProxyContext.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/context/ProxyContext.java
@@ -106,7 +106,7 @@ public class ProxyContext {
 
 	/**
 	 * deleteDirectory is a convenience method to recursively delete a directory
-	 * 
+	 *
 	 * @param directory - the directory to delete.
 	 * @return was the delete succesful
 	 */

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/IncludeDispatchResponseWrapper.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/servlet/IncludeDispatchResponseWrapper.java
@@ -97,7 +97,6 @@ public class IncludeDispatchResponseWrapper extends HttpServletResponseWrapper {
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public void setStatus(int sc, String sm) {
 		return;
 	}

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceProperties.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/internal/util/ServiceProperties.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    Liferay, Inc. - initial API and implementation and/or initial 
+ *    Liferay, Inc. - initial API and implementation and/or initial
  *                    documentation
  ******************************************************************************/
 

--- a/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/session/HttpSessionInvalidator.java
+++ b/bundles/org.eclipse.equinox.http.servlet/src/org/eclipse/equinox/http/servlet/session/HttpSessionInvalidator.java
@@ -27,7 +27,7 @@ package org.eclipse.equinox.http.servlet.session;
  * adopters on the understanding that any code that uses this SPI will almost
  * certainly be broken (repeatedly) as the SPI evolves.
  * </p>
- * 
+ *
  * @since 1.5
  */
 public interface HttpSessionInvalidator {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

