### PR TITLE
Clean Code for bundles/org.eclipse.equinox.registry

### DIFF
--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/adapter/AdapterFactoryProxy.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/adapter/AdapterFactoryProxy.java
@@ -132,7 +132,7 @@ class AdapterFactoryProxy implements IAdapterFactory, IAdapterFactoryExt {
 	/**
 	 * Loads the real adapter factory, but only if its associated plug-in is already
 	 * loaded. Returns the real factory if it was successfully loaded.
-	 * 
+	 *
 	 * @param force if <code>true</code> the plugin providing the factory will be
 	 *              loaded if necessary, otherwise no plugin activations will occur.
 	 */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/BufferedRandomInputStream.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/BufferedRandomInputStream.java
@@ -147,7 +147,7 @@ public class BufferedRandomInputStream extends InputStream {
 
 	/**
 	 * Supplies functionality of the {@link java.io.RandomAccessFile#length()}.
-	 * 
+	 *
 	 * @return file length
 	 */
 	public long length() throws IOException {

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Contribution.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Contribution.java
@@ -178,7 +178,7 @@ public class Contribution implements KeyedElement {
 
 	/**
 	 * Find if this contribution has a children with ID = id.
-	 * 
+	 *
 	 * @param id possible ID of the child
 	 * @return true: contribution has this child
 	 */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionRegistry.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionRegistry.java
@@ -51,7 +51,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see java.lang.Object#hashCode()
 		 */
 		@Override
@@ -307,7 +307,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getConfigurationElementsFor(java.
 	 * lang.String)
@@ -325,7 +325,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getConfigurationElementsFor(java.
 	 * lang.String, java.lang.String)
@@ -342,7 +342,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getConfigurationElementsFor(java.
 	 * lang.String, java.lang.String, java.lang.String)
@@ -373,7 +373,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getExtension(java.lang.String)
 	 */
@@ -405,7 +405,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getExtension(java.lang.String,
 	 * java.lang.String)
@@ -423,7 +423,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getExtension(java.lang.String,
 	 * java.lang.String, java.lang.String)
@@ -440,7 +440,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.IExtensionRegistry#getExtensionPoint(java.lang.
 	 * String)
 	 */
@@ -456,7 +456,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.IExtensionRegistry#getExtensionPoint(java.lang.
 	 * String, java.lang.String)
 	 */
@@ -472,7 +472,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.IExtensionRegistry#getExtensionPoints()
 	 */
 	@Override
@@ -487,7 +487,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getExtensionPoints(java.lang.
 	 * String)
@@ -504,7 +504,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.IExtensionRegistry#getExtensions(java.lang.String)
 	 */
@@ -548,7 +548,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.IExtensionRegistry#getNamespaces()
 	 */
 	@Override
@@ -830,7 +830,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 	/**
 	 * Stops the registry. Registry has to be stopped to properly close cache and
 	 * dispose of listeners.
-	 * 
+	 *
 	 * @param key - key token for this registry
 	 */
 	@Override
@@ -1244,7 +1244,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 	 * method. Proper token should be passed as an argument for non-modifiable
 	 * registries.
 	 * </p>
-	 * 
+	 *
 	 * @param identifier      Id of the extension point. If non-qualified names is
 	 *                        supplied, it will be converted internally into a fully
 	 *                        qualified name
@@ -1340,7 +1340,7 @@ public class ExtensionRegistry implements IExtensionRegistry, IDynamicExtensionR
 	 * method. Proper token should be passed as an argument for non-modifiable
 	 * registries.
 	 * </p>
-	 * 
+	 *
 	 * @see org.eclipse.core.internal.registry.spi.ConfigurationElementDescription
 	 *
 	 * @param identifier            Id of the extension. If non-qualified name is

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionsParser.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ExtensionsParser.java
@@ -161,7 +161,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.xml.sax.helpers.DefaultHandler#setDocumentLocator(org.xml.sax.Locator)
 	 */
@@ -172,7 +172,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#characters(char[], int, int)
 	 */
 	@Override
@@ -201,7 +201,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#endDocument()
 	 */
 	@Override
@@ -211,7 +211,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#endElement(java.lang.String,
 	 * java.lang.String, java.lang.String)
 	 */
@@ -302,7 +302,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#error(org.xml.sax.SAXParseException)
 	 */
 	@Override
@@ -312,7 +312,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.xml.sax.helpers.DefaultHandler#fatalError(org.xml.sax.SAXParseException)
 	 */
@@ -651,7 +651,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#startDocument()
 	 */
 	@Override
@@ -664,7 +664,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.helpers.DefaultHandler#startElement(java.lang.String,
 	 * java.lang.String, java.lang.String, org.xml.sax.Attributes)
 	 */
@@ -694,7 +694,7 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.xml.sax.helpers.DefaultHandler#warning(org.xml.sax.SAXParseException)
 	 */
@@ -709,9 +709,9 @@ public class ExtensionsParser extends DefaultHandler {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.xml.sax.ContentHandler#processingInstruction
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Handle.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/Handle.java
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.InvalidRegistryObjectException;
  * users. The handles never hold on to any "real" content of the object being
  * represented. A handle can become stale if its referenced object has been
  * removed from the registry.
- * 
+ *
  * @since 3.1.
  */
 public abstract class Handle {
@@ -39,7 +39,7 @@ public abstract class Handle {
 
 	/**
 	 * Return the actual object corresponding to this handle.
-	 * 
+	 *
 	 * @throws InvalidRegistryObjectException when the handle is stale.
 	 */
 	abstract RegistryObject getObject();

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/KeyedHashSet.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/KeyedHashSet.java
@@ -42,7 +42,7 @@ public class KeyedHashSet {
 	/**
 	 * Adds an element to this set. If an element with the same key already exists,
 	 * replaces it depending on the replace flag.
-	 * 
+	 *
 	 * @return true if the element was added/stored, false otherwise
 	 */
 	public boolean add(KeyedElement element) {

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ReferenceMap.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/ReferenceMap.java
@@ -103,7 +103,7 @@ public class ReferenceMap {
 	private static interface IEntry {
 		/**
 		 * Returns the integer key for this entry.
-		 * 
+		 *
 		 * @return The integer key
 		 */
 		public int getKey();
@@ -111,14 +111,14 @@ public class ReferenceMap {
 		/**
 		 * Returns the next entry in the linked list of entries with the same hash
 		 * value, or <code>null</code> if there is no next entry.
-		 * 
+		 *
 		 * @return The next entry, or <code>null</code>.
 		 */
 		public IEntry getNext();
 
 		/**
 		 * Returns the value of this entry.
-		 * 
+		 *
 		 * @return The entry value.
 		 */
 		public Object getValue();
@@ -184,7 +184,7 @@ public class ReferenceMap {
 	 * The threshold variable is calculated by multiplying table.length and
 	 * loadFactor. Note: I originally marked this field as final, but then this
 	 * class didn't compile under JDK1.2.2.
-	 * 
+	 *
 	 * @serial
 	 */
 	private final float loadFactor;
@@ -206,7 +206,7 @@ public class ReferenceMap {
 
 	/**
 	 * When size reaches threshold, the map is resized.
-	 * 
+	 *
 	 * @see #resize()
 	 */
 	private transient int threshold;
@@ -214,7 +214,7 @@ public class ReferenceMap {
 	/**
 	 * The reference type for values. Must be HARD or SOFT Note: I originally marked
 	 * this field as final, but then this class didn't compile under JDK1.2.2.
-	 * 
+	 *
 	 * @serial
 	 */
 	int valueType;

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/RegistryTimestamp.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/RegistryTimestamp.java
@@ -22,7 +22,7 @@ package org.eclipse.core.internal.registry;
  * <p>
  * This class is not indended to be subclassed.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.3
  */
 public final class RegistryTimestamp {
@@ -42,7 +42,7 @@ public final class RegistryTimestamp {
 
 	/**
 	 * Returns value of the aggregated timestamp.
-	 * 
+	 *
 	 * @return value of the aggregated timestamp
 	 */
 	public long getContentsTimestamp() {
@@ -51,7 +51,7 @@ public final class RegistryTimestamp {
 
 	/**
 	 * Set value of the aggregated timestamp.
-	 * 
+	 *
 	 * @param timestamp the aggregated timestamp of the current registry contents
 	 */
 	public void set(long timestamp) {
@@ -70,7 +70,7 @@ public final class RegistryTimestamp {
 	/**
 	 * Determines if the aggregate timestamp was modified using add() or remove()
 	 * methods.
-	 * 
+	 *
 	 * @return true: the timestamp was modified after the last set/reset
 	 */
 	public boolean isModifed() {
@@ -79,7 +79,7 @@ public final class RegistryTimestamp {
 
 	/**
 	 * Add individual contribution timestamp to the aggregated timestamp.
-	 * 
+	 *
 	 * @param timestamp the time stamp of the contribution being added to the
 	 *                  registry
 	 */
@@ -90,7 +90,7 @@ public final class RegistryTimestamp {
 
 	/**
 	 * Remove individual contribution timestamp from the aggregated timestamp.
-	 * 
+	 *
 	 * @param timestamp the time stamp of the contribution being removed from the
 	 *                  registry
 	 */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/osgi/RegistryProviderOSGI.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/osgi/RegistryProviderOSGI.java
@@ -26,7 +26,7 @@ public final class RegistryProviderOSGI implements IRegistryProvider {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.equinox.registry.IRegistryProvider#getRegistry()
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementAttribute.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementAttribute.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.IConfigurationElement;
  * <p>
  * This class is not intended to be subclassed.
  * </p>
- * 
+ *
  * @see ConfigurationElementDescription
  * @see IConfigurationElement
  */
@@ -36,14 +36,14 @@ public final class ConfigurationElementAttribute {
 
 	/**
 	 * Attribute name.
-	 * 
+	 *
 	 * @see IConfigurationElement#getAttributeNames()
 	 */
 	private final String name;
 
 	/**
 	 * Attribute value.
-	 * 
+	 *
 	 * @see IConfigurationElement#getAttributeAsIs(String)
 	 */
 	private final String value;
@@ -61,7 +61,7 @@ public final class ConfigurationElementAttribute {
 
 	/**
 	 * Returns attribute name.
-	 * 
+	 *
 	 * @return attribute name
 	 * @see IConfigurationElement#getAttributeNames()
 	 */
@@ -71,7 +71,7 @@ public final class ConfigurationElementAttribute {
 
 	/**
 	 * Returns value of the attribute.
-	 * 
+	 *
 	 * @return attribute value
 	 * @see IConfigurationElement#getAttributeAsIs(String)
 	 */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementDescription.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/internal/registry/spi/ConfigurationElementDescription.java
@@ -31,35 +31,35 @@ import org.eclipse.core.runtime.IConfigurationElement;
  * <p>
  * This class is not intended to be subclassed.
  * </p>
- * 
+ *
  * @see ConfigurationElementAttribute
  */
 public final class ConfigurationElementDescription {
 
 	/**
 	 * Name of the configuration element.
-	 * 
+	 *
 	 * @see IConfigurationElement#getName()
 	 */
 	private final String name;
 
 	/**
 	 * Attributes of the configuration element.
-	 * 
+	 *
 	 * @see IConfigurationElement#getAttribute(String)
 	 */
 	private final ConfigurationElementAttribute[] attributes;
 
 	/**
 	 * String value to be stored in this configuration element.
-	 * 
+	 *
 	 * @see IConfigurationElement#getValue()
 	 */
 	private final String value;
 
 	/**
 	 * Children of the configuration element.
-	 * 
+	 *
 	 * @see IConfigurationElement#getChildren()
 	 */
 	private final ConfigurationElementDescription[] children;
@@ -106,7 +106,7 @@ public final class ConfigurationElementDescription {
 
 	/**
 	 * Returns children of the configuration element.
-	 * 
+	 *
 	 * @return - children of the extension
 	 * @see IConfigurationElement#getChildren()
 	 */
@@ -116,7 +116,7 @@ public final class ConfigurationElementDescription {
 
 	/**
 	 * Returns name of the configuration element.
-	 * 
+	 *
 	 * @return - extension name
 	 * @see IConfigurationElement#getName()
 	 */
@@ -126,7 +126,7 @@ public final class ConfigurationElementDescription {
 
 	/**
 	 * Returns attributes of the configuration element.
-	 * 
+	 *
 	 * @return - attributes of the extension description
 	 * @see IConfigurationElement#getAttribute(String)
 	 */
@@ -136,7 +136,7 @@ public final class ConfigurationElementDescription {
 
 	/**
 	 * Returns string value stored in the configuration element.
-	 * 
+	 *
 	 * @return - String value to be stored in the element
 	 * @see IConfigurationElement#getValue()
 	 */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/ContributorFactoryOSGi.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/ContributorFactoryOSGi.java
@@ -23,7 +23,7 @@ import org.osgi.framework.Bundle;
  * <p>
  * This class can not be extended or instantiated by clients.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/ContributorFactorySimple.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/ContributorFactorySimple.java
@@ -24,7 +24,7 @@ import org.eclipse.core.runtime.spi.RegistryContributor;
  * <p>
  * This class can not be extended or instantiated by clients.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IConfigurationElement.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IConfigurationElement.java
@@ -49,7 +49,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface IConfigurationElement {
@@ -97,7 +97,7 @@ public interface IConfigurationElement {
 	 * The names of configuration element attributes are the same as the attribute
 	 * names of the corresponding XML element. For example, the configuration markup
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &lt;bg pattern="stripes"/&gt;
 	 * </pre>
@@ -131,7 +131,7 @@ public interface IConfigurationElement {
 	 * If multi-language support is not enabled, this method is equivalent to the
 	 * method {@link #getAttribute(String)}.
 	 * </p>
-	 * 
+	 *
 	 * @param attrName the name of the attribute
 	 * @param locale   the requested locale
 	 * @return attribute value, or <code>null</code> if none
@@ -150,7 +150,7 @@ public interface IConfigurationElement {
 	 * The names of configuration element attributes are the same as the attribute
 	 * names of the corresponding XML element. For example, the configuration markup
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &lt;bg pattern="stripes"/&gt;
 	 * </pre>
@@ -182,7 +182,7 @@ public interface IConfigurationElement {
 	 * The names of configuration element attributes are the same as the attribute
 	 * names of the corresponding XML element. For example, the configuration markup
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &lt;bg color="blue" pattern="stripes"/&gt;
 	 * </pre>
@@ -205,7 +205,7 @@ public interface IConfigurationElement {
 	 * Each child corresponds to a nested XML element in the configuration markup.
 	 * For example, the configuration markup
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &lt;view&gt;
 	 * 	&lt;verticalHint&gt;top&lt;/verticalHint&gt;
@@ -250,11 +250,11 @@ public interface IConfigurationElement {
 	 * Returns the name of this configuration element. The name of a configuration
 	 * element is the same as the XML tag of the corresponding XML element. For
 	 * example, the configuration markup
-	 * 
+	 *
 	 * <pre>
 	 * &lt;wizard name="Create Project"/&gt;
 	 * </pre>
-	 * 
+	 *
 	 * corresponds to a configuration element named <code>"wizard"</code>.
 	 *
 	 * @return the name of this configuration element
@@ -279,11 +279,11 @@ public interface IConfigurationElement {
 	/**
 	 * Returns the text value of this configuration element. For example, the
 	 * configuration markup
-	 * 
+	 *
 	 * <pre>
 	 * &lt;script lang="javascript"&gt;.\scripts\cp.js&lt;/script&gt;
 	 * </pre>
-	 * 
+	 *
 	 * corresponds to a configuration element <code>"script"</code> with value
 	 * <code>".\scripts\cp.js"</code>.
 	 * <p>
@@ -313,7 +313,7 @@ public interface IConfigurationElement {
 	 * If multi-language support is not enabled, this method is equivalent to the
 	 * method {@link #getValue()}.
 	 * </p>
-	 * 
+	 *
 	 * @param locale the requested locale
 	 * @return the text value of this configuration element in the specified locale,
 	 *         or <code>null</code>
@@ -328,11 +328,11 @@ public interface IConfigurationElement {
 	/**
 	 * Returns the untranslated text value of this configuration element. For
 	 * example, the configuration markup
-	 * 
+	 *
 	 * <pre>
 	 * &lt;script lang="javascript"&gt;.\scripts\cp.js&lt;/script&gt;
 	 * </pre>
-	 * 
+	 *
 	 * corresponds to a configuration element <code>"script"</code> with value
 	 * <code>".\scripts\cp.js"</code>.
 	 * <p>
@@ -342,7 +342,7 @@ public interface IConfigurationElement {
 	 * Note that translation specified in the plug-in manifest file is <b>not</b>
 	 * automatically applied. For example, the configuration markup
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * &lt;tooltip&gt;#hattip&lt;/tooltip&gt;
 	 * </pre>
@@ -445,7 +445,7 @@ public interface IConfigurationElement {
 
 	/**
 	 * {@inheritDoc}
-	 * 
+	 *
 	 * @return true if the given element has same handle id
 	 * @see #getHandleId()
 	 */
@@ -465,7 +465,7 @@ public interface IConfigurationElement {
 	 * Returns unique identifier of the registry object from which this element was
 	 * created. Two configuration element instances are considered to be equal if
 	 * their handle id's are same.
-	 * 
+	 *
 	 * @return The handle id of the registry object from which this configuration
 	 *         element was created.
 	 * @see #equals(Object)

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IContributor.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IContributor.java
@@ -30,7 +30,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented or extended by clients.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.ContributorFactoryOSGi
  * @see org.eclipse.core.runtime.ContributorFactorySimple
  *

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExecutableExtension.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExecutableExtension.java
@@ -44,7 +44,7 @@ public interface IExecutableExtension {
 	 * Regular executable extensions specify their Java implementation class name as
 	 * an attribute of the configuration element for the extension. For example
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     &lt;action run="com.example.BaseAction"/&gt;
 	 * </pre>
@@ -70,7 +70,7 @@ public interface IExecutableExtension {
 	 * specifies an attribute <code>"run"</code> to contain the name of the
 	 * extension implementation, an adapter can be configured as
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     &lt;action run="com.example.ExternalAdapter:./cmds/util.exe -opt 3"/&gt;
 	 * </pre>
@@ -80,7 +80,7 @@ public interface IExecutableExtension {
 	 * adapter data in the form of xml markup. Using this form, the example above
 	 * would become
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     &lt;action&gt;
 	 *         &lt;run class="com.xyz.ExternalAdapter"&gt;

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExecutableExtensionFactory.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExecutableExtensionFactory.java
@@ -19,7 +19,7 @@ package org.eclipse.core.runtime;
  * instead of referring to a class. For example, the following extension to the
  * preference page extension-point uses a factory called
  * <code>PreferencePageFactory</code>.
- * 
+ *
  * <pre>
  * <code>
  *  &lt;extension point="org.eclipse.ui.preferencePages"&gt;
@@ -47,7 +47,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface can be used without OSGi running.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.IConfigurationElement
  */
 public interface IExecutableExtensionFactory {

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionDelta.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionDelta.java
@@ -21,7 +21,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @since 3.0
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -29,14 +29,14 @@ public interface IExtensionDelta {
 	/**
 	 * Delta kind constant indicating that an extension has been added to an
 	 * extension point.
-	 * 
+	 *
 	 * @see IExtensionDelta#getKind()
 	 */
 	public int ADDED = 1;
 	/**
 	 * Delta kind constant indicating that an extension has been removed from an
 	 * extension point.
-	 * 
+	 *
 	 * @see IExtensionDelta#getKind()
 	 */
 	public int REMOVED = 2;

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionPoint.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionPoint.java
@@ -47,7 +47,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface IExtensionPoint {
@@ -198,7 +198,7 @@ public interface IExtensionPoint {
 	 * If multi-language support is not enabled, this method is equivalent to the
 	 * method {@link #getLabel()}.
 	 * </p>
-	 * 
+	 *
 	 * @param locale the requested locale
 	 * @return a displayable string label for this extension point, possibly the
 	 *         empty string
@@ -248,7 +248,7 @@ public interface IExtensionPoint {
 
 	/*
 	 * (non-javadoc)
-	 * 
+	 *
 	 * @see Object#equals(java.lang.Object)
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionRegistry.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IExtensionRegistry.java
@@ -58,7 +58,7 @@ import java.util.ResourceBundle;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @since 3.0
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -79,7 +79,7 @@ public interface IExtensionRegistry {
 	 * registry. Registry change notifications are sent asynchronously. The listener
 	 * continues to receive notifications until it is removed.
 	 * </p>
-	 * 
+	 *
 	 * @param listener  the listener
 	 * @param namespace the namespace in which to listen for changes
 	 * @see IRegistryChangeListener
@@ -99,7 +99,7 @@ public interface IExtensionRegistry {
 	 * <p>
 	 * This method is equivalent to:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * addRegistryChangeListener(listener, null);
 	 * </pre>
@@ -259,7 +259,7 @@ public interface IExtensionRegistry {
 	/**
 	 * Returns all extensions supplied by the contributor, or <code>null</code> if
 	 * there are no such extensions.
-	 * 
+	 *
 	 * @param contributor the contributor for the extensions (for OSGi registry,
 	 *                    bundles and fragments are different contributors)
 	 * @return the extensions, or <code>null</code>
@@ -277,7 +277,7 @@ public interface IExtensionRegistry {
 	 * a package name and a class name). The simple names are presumed to be unique
 	 * in the namespace.
 	 * </p>
-	 * 
+	 *
 	 * @return all namespaces known to this registry
 	 */
 	public String[] getNamespaces();
@@ -308,7 +308,7 @@ public interface IExtensionRegistry {
 	 * master token and a user token. Master token allows all operations; user token
 	 * allows non-persisted registry elements to be modified.
 	 * </p>
-	 * 
+	 *
 	 * @param is                stream open on the XML file. The XML file can
 	 *                          contain an extension point(s) or/and extension(s)
 	 *                          described in the format similar to plugin.xml. The
@@ -343,7 +343,7 @@ public interface IExtensionRegistry {
 	 * master token and a user token. Master token allows all operations; user token
 	 * only allows non-persisted registry elements to be modified.
 	 * </p>
-	 * 
+	 *
 	 * @param extension extension to be removed
 	 * @param token     the key used to check permissions
 	 * @return <code>true</code> if the extension was successfully removed, and
@@ -364,7 +364,7 @@ public interface IExtensionRegistry {
 	 * master token and a user token. Master token allows all operations; user token
 	 * only allows non-persisted registry elements to be modified.
 	 * </p>
-	 * 
+	 *
 	 * @param extensionPoint extension point to be removed
 	 * @param token          the key used to check permissions
 	 * @return <code>true</code> if the extension point was successfully removed,
@@ -383,7 +383,7 @@ public interface IExtensionRegistry {
 	 * This method is an access controlled method. Master token should be passed as
 	 * an argument.
 	 * </p>
-	 * 
+	 *
 	 * @see RegistryFactory#createRegistry(org.eclipse.core.runtime.spi.RegistryStrategy,
 	 *      Object, Object)
 	 * @param token master token for the registry
@@ -410,7 +410,7 @@ public interface IExtensionRegistry {
 	 * <p>
 	 * This method has no effect if the listener is already registered.
 	 * </p>
-	 * 
+	 *
 	 * @param listener the listener
 	 * @since org.eclipse.equinox.registry 3.4
 	 */
@@ -427,7 +427,7 @@ public interface IExtensionRegistry {
 	 * <p>
 	 * This method has no effect if the listener is already registered.
 	 * </p>
-	 * 
+	 *
 	 * @param listener         the listener
 	 * @param extensionPointId the unique identifier of extension point
 	 * @see IExtensionPoint#getUniqueIdentifier()
@@ -440,7 +440,7 @@ public interface IExtensionRegistry {
 	 * <p>
 	 * This method has no effect if the listener is not registered.
 	 * </p>
-	 * 
+	 *
 	 * @param listener the listener
 	 * @see #addListener(IRegistryEventListener)
 	 * @see #addListener(IRegistryEventListener, String)
@@ -455,7 +455,7 @@ public interface IExtensionRegistry {
 	 * See the runtime option "-registryMultiLanguage" for enabling multi-language
 	 * support.
 	 * </p>
-	 * 
+	 *
 	 * @return <code>true</code> if multiple languages are supported by this
 	 *         instance of the extension registry; <code>false</code> otherwise.
 	 * @since org.eclipse.equinox.registry 3.5

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IRegistryChangeEvent.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IRegistryChangeEvent.java
@@ -21,7 +21,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @since 3.0
  * @see IExtensionRegistry
  * @see IRegistryChangeListener

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IRegistryEventListener.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/IRegistryEventListener.java
@@ -27,7 +27,7 @@ import java.util.EventListener;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @see IExtensionRegistry#addListener(IRegistryEventListener, String)
  * @since 3.4
  */
@@ -39,7 +39,7 @@ public interface IRegistryEventListener extends EventListener {
 	 * The extensions supplied as the argument are valid only for the duration of
 	 * the invocation of this method.
 	 * </p>
-	 * 
+	 *
 	 * @param extensions extensions added to the registry
 	 */
 	public void added(IExtension[] extensions);
@@ -50,7 +50,7 @@ public interface IRegistryEventListener extends EventListener {
 	 * The extensions supplied as the argument are valid only for the duration of
 	 * the invocation of this method.
 	 * </p>
-	 * 
+	 *
 	 * @param extensions extensions removed from the registry
 	 */
 	public void removed(IExtension[] extensions);
@@ -61,7 +61,7 @@ public interface IRegistryEventListener extends EventListener {
 	 * The extension points supplied as the argument are valid only for the duration
 	 * of the invocation of this method.
 	 * </p>
-	 * 
+	 *
 	 * @param extensionPoints extension points added to the registry
 	 */
 	public void added(IExtensionPoint[] extensionPoints);
@@ -72,7 +72,7 @@ public interface IRegistryEventListener extends EventListener {
 	 * The extension points supplied as the argument are valid only for the duration
 	 * of the invocation of this method.
 	 * </p>
-	 * 
+	 *
 	 * @param extensionPoints extension points removed from the registry
 	 */
 	public void removed(IExtensionPoint[] extensionPoints);

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/InvalidRegistryObjectException.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/InvalidRegistryObjectException.java
@@ -23,7 +23,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.
  */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/RegistryFactory.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/RegistryFactory.java
@@ -33,7 +33,7 @@ import org.eclipse.core.runtime.spi.RegistryStrategy;
  * <p>
  * This class is not intended to be subclassed or instantiated.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
@@ -57,7 +57,7 @@ public final class RegistryFactory {
 	 * users attempting to modify dynamic contributions to the registry have to use
 	 * the user token. Users may pass in <code>null</code> as a user token.
 	 * </p>
-	 * 
+	 *
 	 * @param strategy    registry strategy or <code>null</code>
 	 * @param masterToken the token used for master control of the registry or
 	 *                    <code>null</code>
@@ -109,7 +109,7 @@ public final class RegistryFactory {
 	 * The master token should be passed to the OSGi registry strategy to permit it
 	 * to perform contributions to the registry.
 	 * </p>
-	 * 
+	 *
 	 * @param storageDirs   array of file system directories or <code>null</code>
 	 * @param cacheReadOnly array of read only attributes or <code>null</code>
 	 * @param token         control token for the registry
@@ -128,7 +128,7 @@ public final class RegistryFactory {
 	 * <p>
 	 * The given registry provider must not be <code>null</code>.
 	 * </p>
-	 * 
+	 *
 	 * @see RegistryFactory#getRegistry()
 	 * @param provider extension registry provider
 	 * @throws CoreException if a default registry provider was already set for this

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/ExtensionTracker.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/ExtensionTracker.java
@@ -26,7 +26,7 @@ import org.eclipse.core.runtime.*;
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.dynamichelpers.IExtensionTracker
  * @since 3.1
  */
@@ -67,7 +67,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.core.runtime.dynamichelpers.IExtensionTracker#registerHandler(org
 	 * .eclipse.core.runtime.dynamichelpers.IExtensionChangeHandler,
@@ -86,7 +86,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@unregisterHandler(IExtensionChangeHandler)
 	 */
 	@Override
@@ -101,7 +101,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@registerObject(IExtension, Object, int)
 	 */
 	@Override
@@ -215,7 +215,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@getObjects(IExtension)
 	 */
 	@Override
@@ -235,7 +235,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@close()
 	 */
 	@Override
@@ -256,7 +256,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@unregisterObject(IExtension, Object)
 	 */
 	@Override
@@ -274,7 +274,7 @@ public class ExtensionTracker implements IExtensionTracker, IRegistryChangeListe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see IExtensionTracker@unregisterObject(IExtension)
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IExtensionChangeHandler.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IExtensionChangeHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.core.runtime.IExtension;
  * <p>
  * This interface is intended to be implemented by clients.
  * </p>
- * 
+ *
  * @since 3.1
  */
 public interface IExtensionChangeHandler {

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IExtensionTracker.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IExtensionTracker.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.IExtension;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @since 3.1
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IFilter.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/dynamichelpers/IFilter.java
@@ -25,7 +25,7 @@ import org.eclipse.core.runtime.IExtensionPoint;
  * <p>
  * This interface can be used without OSGi running.
  * </p>
- * 
+ *
  * @since 3.1
  */
 public interface IFilter {

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/IDynamicExtensionRegistry.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/IDynamicExtensionRegistry.java
@@ -38,7 +38,7 @@ import org.eclipse.core.runtime.IContributor;
  * <p>
  * This interface can be used without OSGi running.
  * </p>
- * 
+ *
  * @since 3.4
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
@@ -51,7 +51,7 @@ public interface IDynamicExtensionRegistry {
 	 * This method is an access controlled method. Access tokens are specified when
 	 * the registry is constructed by the registry implementers.
 	 * </p>
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.RegistryFactory#createRegistry(RegistryStrategy,
 	 *      Object, Object)
 	 * @param contributor the contributor to be removed
@@ -61,7 +61,7 @@ public interface IDynamicExtensionRegistry {
 
 	/**
 	 * Finds out if registry has the contributor.
-	 * 
+	 *
 	 * @param contributor registry contributor
 	 * @return true if the registry has this contributor; false otherwise
 	 */
@@ -69,7 +69,7 @@ public interface IDynamicExtensionRegistry {
 
 	/**
 	 * Returns all contributors associated with the registry at this time.
-	 * 
+	 *
 	 * @return all contributors associated with the registry
 	 */
 	public IContributor[] getAllContributors();

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/IRegistryProvider.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/IRegistryProvider.java
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.IExtensionRegistry;
  * <p>
  * This interface may be implemented by clients.
  * </p>
- * 
+ *
  * @see org.eclipse.core.runtime.RegistryFactory#getRegistry()
  * @see org.eclipse.core.runtime.RegistryFactory#setDefaultRegistryProvider(IRegistryProvider)
  * @since org.eclipse.equinox.registry 3.2

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryContributor.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryContributor.java
@@ -30,7 +30,7 @@ import org.eclipse.core.runtime.IContributor;
  * <p>
  * This class can not be extended.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.2
  * @noextend This class is not intended to be subclassed by clients.
  */
@@ -90,7 +90,7 @@ public final class RegistryContributor implements IContributor {
 	 * example, if ID of 12 was used to identify contributorA, the ID of 12 can not
 	 * be used to identify contributorB or a host for the contributorC.
 	 * </p>
-	 * 
+	 *
 	 * @param actualId   contributor identifier
 	 * @param actualName name of the contributor
 	 * @param hostId     id associated with the host, or <code>null</code>
@@ -153,7 +153,7 @@ public final class RegistryContributor implements IContributor {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see java.lang.Object#toString()
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryStrategy.java
+++ b/bundles/org.eclipse.equinox.registry/src/org/eclipse/core/runtime/spi/RegistryStrategy.java
@@ -40,7 +40,7 @@ import org.eclipse.osgi.util.NLS;
  * <p>
  * This class can be overridden and/or instantiated by clients.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.registry 3.2
  */
 public class RegistryStrategy {
@@ -131,7 +131,7 @@ public class RegistryStrategy {
 	 * This method writes a message to <code>System.out</code> in the following
 	 * format:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * [Error|Warning|Log]: Main error message
 	 * [Error|Warning|Log]: Child error message 1
@@ -171,7 +171,7 @@ public class RegistryStrategy {
 	 * and {@link #onStart(IExtensionRegistry, boolean)} as both methods will be
 	 * called on the registry startup.
 	 * </p>
-	 * 
+	 *
 	 * @param registry the extension registry being started
 	 *
 	 * @deprecated use {@link #onStart(IExtensionRegistry, boolean)}.
@@ -200,7 +200,7 @@ public class RegistryStrategy {
 	 * Override this method to provide additional processing to be performed just
 	 * before the registry is stopped. Overrides should call
 	 * <code>super.onStop()</code> at the end of the processing.
-	 * 
+	 *
 	 * @param registry the extension registry being stopped
 	 */
 	public void onStop(IExtensionRegistry registry) {
@@ -259,7 +259,7 @@ public class RegistryStrategy {
 	 * Override this method to customize scheduling of an extension registry event.
 	 * Note that this method <strong>must</strong> make the following call to
 	 * actually process the event:
-	 * 
+	 *
 	 * <pre>
 	 * <code>
 	 * 	RegistryStrategy.processChangeEvent(listeners, deltas, registry);
@@ -418,7 +418,7 @@ public class RegistryStrategy {
 	 * This method may return 0 to indicate that no time stamp verification is
 	 * required.
 	 * </p>
-	 * 
+	 *
 	 * @return a value corresponding to the last modification time of contributions
 	 *         contained in the registry
 	 */
@@ -458,7 +458,7 @@ public class RegistryStrategy {
 	 * <p>
 	 * This method is only used if multi-language support is enabled.
 	 * </p>
-	 * 
+	 *
 	 * @param nonTranslated message keys to be translated
 	 * @param contributor   the contributor of the keys to be translated
 	 * @param locale        the requested locale for the keys
@@ -488,7 +488,7 @@ public class RegistryStrategy {
 	 * <p>
 	 * This method is only used if multi-language support is enabled.
 	 * </p>
-	 * 
+	 *
 	 * @see IExtensionRegistry#isMultiLanguage()
 	 * @return the default locale
 	 * @since org.eclipse.equinox.registry 3.5


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

