### PR TITLE
Clean Code for bundles/org.eclipse.equinox.weaving.caching

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,15 +4,14 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@master
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@add_manifest_cleanup_profile
     with:
       author: Eclipse Equinox Bot <equinox-bot@eclipse.org>
       do-quickfix: false
       do-cleanups: true
+      do-manifest: true
     secrets:
       token: ${{ secrets.EQUINOX_BOT_PAT }}

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Activator.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Activator.java
@@ -84,7 +84,7 @@ public class Activator implements BundleActivator {
 	/**
 	 * Registers a new {@link CachingServiceFactory} instance as OSGi service under
 	 * the interface {@link ICachingService}.
-	 * 
+	 *
 	 * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
 	 */
 	@Override
@@ -106,7 +106,7 @@ public class Activator implements BundleActivator {
 
 	/**
 	 * Shuts down the {@link CachingServiceFactory}.
-	 * 
+	 *
 	 * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItem.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CacheItem.java
@@ -35,7 +35,7 @@ public class CacheItem {
 
 	/**
 	 * Create a new item to be cached
-	 * 
+	 *
 	 * @param cachedBytes The bytes to be written to the cache
 	 * @param directory   The directory to where the bytes should be stored
 	 * @param name        The name of the file to store the bytes in
@@ -46,7 +46,7 @@ public class CacheItem {
 
 	/**
 	 * Create a new item to be cached
-	 * 
+	 *
 	 * @param cachedBytes      The bytes to be written to the cache
 	 * @param directory        The directory to where the bytes should be stored
 	 * @param name             The name of the file to store the bytes in

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/CachingServiceFactory.java
@@ -122,7 +122,7 @@ public class CachingServiceFactory implements ICachingServiceFactory {
 	/**
 	 * Generates the unique id for the cache of the given bundle (usually the
 	 * symbolic name and the bundle version)
-	 * 
+	 *
 	 * @param bundle The bundle for which a unique cache id should be calculated
 	 * @return The unique id of the cache for the given bundle
 	 */
@@ -144,7 +144,7 @@ public class CachingServiceFactory implements ICachingServiceFactory {
 
 	/**
 	 * Stops individual bundle caching service if the bundle is uninstalled
-	 * 
+	 *
 	 * @param event The event contains the information for which bundle to stop the
 	 *              caching service
 	 */

--- a/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Log.java
+++ b/bundles/org.eclipse.equinox.weaving.caching/src/org/eclipse/equinox/weaving/internal/caching/Log.java
@@ -29,7 +29,7 @@ public class Log {
 
 	/**
 	 * Logging debug information.
-	 * 
+	 *
 	 * @param message The tracing message, optional.
 	 */
 	public static void debug(final String message) {
@@ -42,7 +42,7 @@ public class Log {
 
 	/**
 	 * Logging an error.
-	 * 
+	 *
 	 * @param message The error message, optional.
 	 * @param t       The Throwable for this error, optional.
 	 */
@@ -57,7 +57,7 @@ public class Log {
 
 	/**
 	 * Shows debug toggle state.
-	 * 
+	 *
 	 * @return true, if debug is enabled, else false.
 	 */
 	public static boolean isDebugEnabled() {

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,79 @@
               </ignores>
           </configuration>
       </plugin>
+	    <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-cleancode-plugin</artifactId>
+          <version>${tycho.version}</version>
+        <executions>
+            <execution>
+                <id>cleanups</id>
+                <configuration>
+                    <cleanUpProfile>
+                        <!-- Make inner classes static where possible-->
+                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
+                        <!-- Add missing annotations -->
+                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+                        <!-- Add missing '@Deprecated' annotations-->
+                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+                        <!-- Use 'final' where possible -->
+                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+                        <!-- Add final modifier to private fields -->
+                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+                        <!-- Replace deprecated calls with inlined content where possible -->
+                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+                        <!-- Convert control statement bodies to block -->
+                        <cleanup.use_blocks>true</cleanup.use_blocks>
+                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
+                        <!-- Use pattern matching for instanceof -->
+                        <cleanup.instanceof>true</cleanup.instanceof>
+                        <!-- Remove unnecessary array creation -->
+                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
+                        <!-- Remove unnecessary suppress warning tokens -->
+                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
+						<!-- Remove unnecessary whitespace-->
+                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
+                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
+                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
+                        <!-- Removes unused imports -->
+                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
+                        <cleanup.organize_imports>false</cleanup.organize_imports>
+                    </cleanUpProfile>
+                </configuration>
+            </execution>
+            <execution>
+                <id>quickfixes</id>
+                <configuration>
+                    <baselines>
+                         <repository>
+                             <url>${previous-release.baseline}</url>
+                         </repository>
+                    </baselines>
+                    <bundles>
+                        <bundle>org.eclipse.ui.ide.application</bundle>
+                    </bundles>
+                    <application>org.eclipse.ui.ide.workbench</application>
+                    <quickfixes>
+                        <quickfix>org.eclipse.jdt.ui</quickfix>
+                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
+                    </quickfixes>
+                </configuration>
+            </execution>
+            <execution>
+                <id>manifest</id>
+                <configuration>
+                    <calculateUses>true</calculateUses>
+                </configuration>
+            </execution>
+        </executions>
+          <configuration>
+                <local>true</local>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -268,81 +268,10 @@
                   <ignore>osgi/src/.*</ignore>
                   <ignore>felix/src_test/.*</ignore>
               </ignores>
+		  <calculateUses>true</calculateUses>
           </configuration>
       </plugin>
-	    <plugin>
-          <groupId>org.eclipse.tycho</groupId>
-          <artifactId>tycho-cleancode-plugin</artifactId>
-          <version>${tycho.version}</version>
-        <executions>
-            <execution>
-                <id>cleanups</id>
-                <configuration>
-                    <cleanUpProfile>
-                        <!-- Make inner classes static where possible-->
-                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
-                        <!-- Add missing annotations -->
-                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
-                        <!-- Add missing '@Deprecated' annotations-->
-                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
-                        <!-- Use 'final' where possible -->
-                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
-                        <!-- Add final modifier to private fields -->
-                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
-                        <!-- Replace deprecated calls with inlined content where possible -->
-                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
-                        <!-- Convert control statement bodies to block -->
-                        <cleanup.use_blocks>true</cleanup.use_blocks>
-                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
-                        <!-- Use pattern matching for instanceof -->
-                        <cleanup.instanceof>true</cleanup.instanceof>
-                        <!-- Remove unnecessary array creation -->
-                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
-                        <!-- Remove unnecessary suppress warning tokens -->
-                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
-						<!-- Remove unnecessary whitespace-->
-                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
-                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
-                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
-                        <!-- Removes unused imports -->
-                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
-                        <cleanup.organize_imports>false</cleanup.organize_imports>
-                    </cleanUpProfile>
-                </configuration>
-            </execution>
-            <execution>
-                <id>quickfixes</id>
-                <configuration>
-                    <baselines>
-                         <repository>
-                             <url>${previous-release.baseline}</url>
-                         </repository>
-                    </baselines>
-                    <bundles>
-                        <bundle>org.eclipse.ui.ide.application</bundle>
-                    </bundles>
-                    <application>org.eclipse.ui.ide.workbench</application>
-                    <quickfixes>
-                        <quickfix>org.eclipse.jdt.ui</quickfix>
-                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
-                    </quickfixes>
-                </configuration>
-            </execution>
-            <execution>
-                <id>manifest</id>
-                <configuration>
-                    <calculateUses>true</calculateUses>
-                </configuration>
-            </execution>
-        </executions>
-          <configuration>
-                <local>true</local>
-            </configuration>
-        </plugin>
+	    
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

