### PR TITLE
Clean Code for bundles/org.eclipse.equinox.weaving.hook

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,15 +4,14 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@master
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@add_manifest_cleanup_profile
     with:
       author: Eclipse Equinox Bot <equinox-bot@eclipse.org>
       do-quickfix: false
       do-cleanups: true
+      do-manifest: true
     secrets:
       token: ${{ secrets.EQUINOX_BOT_PAT }}

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/CacheEntry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/CacheEntry.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert              initial implementation      
+ *   Martin Lippert              initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.service.weaving;
@@ -17,13 +17,13 @@ package org.eclipse.equinox.service.weaving;
 /**
  * A CacheEntry represents an item that is read (or should have been read) from
  * the cache.
- * 
+ *
  * A cache entry is the primary communication item between the basic hook
  * mechanism and the cache implementation. The cache can tell the hook to skip
  * any weaving for the class (in the case the cache knows that the class don't
  * need any weaving, e.g. no aspects affect this class) or to use the bytes that
  * are read from the cache to define the class in the VM.
- * 
+ *
  * @author Martin Lippert
  */
 public class CacheEntry {
@@ -36,7 +36,7 @@ public class CacheEntry {
 	 * Creates a new cache entry. This item can tell the basic hook mechanism to use
 	 * the given cached bytes for the class definition or if the original class
 	 * bytes needs weaving or not
-	 * 
+	 *
 	 * @param dontWeave   A flag that indicates whether this item needs to be woven
 	 *                    or not
 	 * @param cachedBytes The bytes for the class read from the cache
@@ -48,7 +48,7 @@ public class CacheEntry {
 
 	/**
 	 * Tell the hook mechanism to weave a class or not to weave a class
-	 * 
+	 *
 	 * @return true, if the class doesn't need any weaving, otherwise false
 	 */
 	public boolean dontWeave() {
@@ -58,7 +58,7 @@ public class CacheEntry {
 	/**
 	 * Returns the bytes that are read from the cache. These bytes should be used
 	 * for defining the class instead of the original ones.
-	 * 
+	 *
 	 * @return The cached bytes for the class
 	 */
 	public byte[] getCachedBytes() {

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ICachingService.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ICachingService.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
- *   Matthew Webster           Eclipse 3.2 changes     
+ *   David Knibb               initial implementation
+ *   Matthew Webster           Eclipse 3.2 changes
  *   Martin Lippert            extracted caching service factory
  *   Martin Lippert            caching of generated classes
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ICachingServiceFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ICachingServiceFactory.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert               initial implementation      
+ *   Martin Lippert               initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.service.weaving;
@@ -21,7 +21,7 @@ import org.osgi.framework.Bundle;
  * like to contribute a concrete caching implementation. Bundles should
  * implement this interface and register an implementation as an OSGi service
  * under this interface.
- * 
+ *
  * @author Martin Lippert
  */
 public interface ICachingServiceFactory {
@@ -30,7 +30,7 @@ public interface ICachingServiceFactory {
 	 * Create concrete caching service for the given bundle. The caching service is
 	 * then responsible to cache woven bytecode and retrieve those bytecodes from
 	 * the cache.
-	 * 
+	 *
 	 * @param classLoader The classloader if the given bundle
 	 * @param bundle      The bundle the caching service should be created for
 	 * @param key         A fingerprint that is created by the concrete weavers to

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ISupplementerRegistry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/ISupplementerRegistry.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert            initial implementation     
+ *   Martin Lippert            initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.service.weaving;
@@ -40,7 +40,7 @@ public interface ISupplementerRegistry {
 
 	/**
 	 * Refreshes the given bundles
-	 * 
+	 *
 	 * @param bundles The bundles to refresh
 	 */
 	public void refreshBundles(final Bundle[] bundles);

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/IWeavingService.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/IWeavingService.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *   David Knibb               initial implementation
  *   Matthew Webster           Eclipse 3.2 changes
@@ -24,7 +24,7 @@ import java.util.Map;
  * The IWeavingService is the interface for weavers for individual bundles. This
  * weaver is used by the core equinox aspects runtime to weave bytecodes when a
  * class is loaded and not read from cache.
- * 
+ *
  * @author Martin Lippert
  */
 public interface IWeavingService {
@@ -32,14 +32,14 @@ public interface IWeavingService {
 	/**
 	 * Flush all generated classes from the weaving service so that memory kept by
 	 * the weaving service for additional classes can be freed.
-	 * 
+	 *
 	 * @param loader The class loader the weaving service belongs to
 	 */
 	public void flushGeneratedClasses(ClassLoader loader);
 
 	/**
 	 * Has the weaving service generated new classes on the fly for the given class?
-	 * 
+	 *
 	 * @param loader    The class loader of the woven class
 	 * @param className The name of the woven class
 	 * @return true, if the weaving service has generated additional classes for the
@@ -52,7 +52,7 @@ public interface IWeavingService {
 	 * Implementations of this method should remove those classes from internal
 	 * lists (to free memory). This means also that calling this method a second
 	 * time will return an emptry map.
-	 * 
+	 *
 	 * @param className The name of the class for which additional classes were
 	 *                  generated
 	 * @return The generated classes (key: generated class name, value: generated
@@ -67,7 +67,7 @@ public interface IWeavingService {
 	 * key to feed the caching service. This means, the weaver should return
 	 * different keys for different set of aspects (including versions),
 	 * respectively when the cache should switch its context.
-	 * 
+	 *
 	 * @return A unique key to define the set of aspects that are woven into the
 	 *         bundle to which this weaver belongs
 	 */
@@ -76,7 +76,7 @@ public interface IWeavingService {
 	/**
 	 * This method is called for each class which is loaded into the JVM and not
 	 * read from cache to do the actual weaving, if necessary.
-	 * 
+	 *
 	 * @param name       The fully qualified name of the class to be loaded
 	 * @param classbytes The original unmodified bytecode of the class read by the
 	 *                   standard OSGi classloading mechanism

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/IWeavingServiceFactory.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/IWeavingServiceFactory.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert               initial implementation      
+ *   Martin Lippert               initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.service.weaving;
@@ -22,7 +22,7 @@ import org.osgi.framework.wiring.BundleRevision;
  * like to contribute a concrete weaving mechanism. Bundles should implement
  * this interface and register an implementation as an OSGi service under this
  * interface.
- * 
+ *
  * @author Martin Lippert
  */
 public interface IWeavingServiceFactory {
@@ -31,7 +31,7 @@ public interface IWeavingServiceFactory {
 	 * Create a concrete weaving implementation for the given bundle. This is called
 	 * by the basic equinox aspects weaving hook mechanism lazily when the
 	 * classloader for the bundle is created.
-	 * 
+	 *
 	 * @param loader               The classloader of the bundle for which to create
 	 *                             a weaver
 	 * @param bundle               The bundle for which to create the weaver

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/Supplementer.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/service/weaving/Supplementer.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
- *   Martin Lippert            supplementing mechanism reworked     
+ *   David Knibb               initial implementation
+ *   Martin Lippert            supplementing mechanism reworked
  *   Martin Lippert            fragment handling fixed
  *******************************************************************************/
 
@@ -25,10 +25,10 @@ import org.osgi.framework.Bundle;
 /**
  * A supplementer object is created for every bundle that contains one or many
  * of the supplementer headers in its header.
- * 
+ *
  * The corresponding supplementer object contains the information which headers
  * the bundle defines and which bundles it supplements in the running system.
- * 
+ *
  * @author Martin Lippert
  */
 public class Supplementer {
@@ -47,7 +47,7 @@ public class Supplementer {
 
 	/**
 	 * Creates a supplementer object for the given bundle.
-	 * 
+	 *
 	 * @param bundle             The bundle that defines the supplementer headers
 	 * @param bundleHost         The host bundle of the supplementer bundle, if the
 	 *                           bundle is a fragment, otherwise null
@@ -70,7 +70,7 @@ public class Supplementer {
 
 	/**
 	 * Add a bundle to the list of supplemented bundles
-	 * 
+	 *
 	 * @param supplementedBundle The bundle that is supplemented by this
 	 *                           supplementer
 	 */
@@ -101,7 +101,7 @@ public class Supplementer {
 	/**
 	 * Gives information about which bundles are currently supplemented by this
 	 * supplementer
-	 * 
+	 *
 	 * @return The currently supplemented bundles
 	 */
 	public Bundle[] getSupplementedBundles() {
@@ -111,7 +111,7 @@ public class Supplementer {
 	/**
 	 * Returns the bundle that defines the supplementer headers (this supplementer
 	 * object belongs to)
-	 * 
+	 *
 	 * @return The bundle object this supplementer belongs to
 	 */
 	public Bundle getSupplementerBundle() {
@@ -121,7 +121,7 @@ public class Supplementer {
 	/**
 	 * Returns the host of the supplementer bundle, if it is a fragment, otherwise
 	 * this returns the same as getSupplementerBundle()
-	 * 
+	 *
 	 * @return The host bundle this supplementer belongs to
 	 */
 	public Bundle getSupplementerHost() {
@@ -130,7 +130,7 @@ public class Supplementer {
 
 	/**
 	 * The symbolic name of the supplementer bundle
-	 * 
+	 *
 	 * @return The symbolic name of the supplementer bundle
 	 */
 	public String getSymbolicName() {
@@ -140,7 +140,7 @@ public class Supplementer {
 	/**
 	 * Provides information about whether a given bundle is supplemented by this
 	 * supplementer or not
-	 * 
+	 *
 	 * @param bundle The bundle that might be supplemented by this supplementer
 	 * @return true, if the bundle is supplemented by this supplementer, otherwise
 	 *         false
@@ -152,7 +152,7 @@ public class Supplementer {
 	/**
 	 * Checks if the given export-package header definitions matches the
 	 * supplement-exporter definitions of this supplementer
-	 * 
+	 *
 	 * @param exports The headers to check for matching against this supplementer
 	 * @return true, if this supplementer matches against the given export-package
 	 *         headers
@@ -178,7 +178,7 @@ public class Supplementer {
 	/**
 	 * Checks if the given import-package header definitions matches the
 	 * supplement-importer definitions of this supplementer
-	 * 
+	 *
 	 * @param imports The headers to check for matching against this supplementer
 	 * @return true, if this supplementer matches against the given import-package
 	 *         headers
@@ -204,7 +204,7 @@ public class Supplementer {
 	/**
 	 * Checks if the given bundle symbolic name definition matches the
 	 * supplement-bundle definition of this supplementer
-	 * 
+	 *
 	 * @param symbolicName The symbolic name of the bundle that shoudl be checked
 	 * @return true, if this supplementer matches against the given bundle symbolic
 	 *         name
@@ -227,7 +227,7 @@ public class Supplementer {
 	/**
 	 * Removes the given bundle from the set of supplemented bundles (that are
 	 * supplemented by this supplementer)
-	 * 
+	 *
 	 * @param supplementedBundle The bundle that is no longer supplemented by this
 	 *                           supplementer
 	 */

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/Debug.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/Debug.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Matthew Webster           initial implementation      
+ *   Matthew Webster           initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.adaptors;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/IWeavingAdaptor.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/IWeavingAdaptor.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
- *   Matthew Webster           Eclipse 3.2 changes     
+ *   David Knibb               initial implementation
+ *   Matthew Webster           Eclipse 3.2 changes
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.adaptors;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptor.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/adaptors/WeavingAdaptor.java
@@ -7,11 +7,11 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
+ *   David Knibb               initial implementation
  *   Matthew Webster           Eclipse 3.2 changes
- *   Martin Lippert            minor changes and bugfixes     
+ *   Martin Lippert            minor changes and bugfixes
  *   Martin Lippert            caching of generated classes
  *******************************************************************************/
 

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/AbstractWeavingBundleFile.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/AbstractWeavingBundleFile.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
- *   Matthew Webster           Eclipse 3.2 changes     
+ *   David Knibb               initial implementation
+ *   Matthew Webster           Eclipse 3.2 changes
  *   Martin Lippert            caching of generated classes
  *******************************************************************************/
 

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/BaseWeavingBundleFile.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/BaseWeavingBundleFile.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
- *   Matthew Webster           Eclipse 3.2 changes     
+ *   David Knibb               initial implementation
+ *   Matthew Webster           Eclipse 3.2 changes
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.hooks;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/CachedClassBundleEntry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/CachedClassBundleEntry.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert               initial implementation      
+ *   Martin Lippert               initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.hooks;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/CachedGeneratedClassBundleEntry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/CachedGeneratedClassBundleEntry.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert               initial implementation      
+ *   Martin Lippert               initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.hooks;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/SupplementBundleListener.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/SupplementBundleListener.java
@@ -7,9 +7,9 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   Martin Lippert               initial implementation      
+ *   Martin Lippert               initial implementation
  *******************************************************************************/
 
 package org.eclipse.equinox.weaving.hooks;

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingBundleEntry.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingBundleEntry.java
@@ -7,11 +7,11 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
+ *   David Knibb               initial implementation
  *   Matthew Webster           Eclipse 3.2 changes
- *   Martin Lippert            minor changes and bugfixes     
+ *   Martin Lippert            minor changes and bugfixes
  *   Martin Lippert            splitted into different types of bundle entries
  *******************************************************************************/
 

--- a/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingBundleFile.java
+++ b/bundles/org.eclipse.equinox.weaving.hook/src/org/eclipse/equinox/weaving/hooks/WeavingBundleFile.java
@@ -7,11 +7,11 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
- *   David Knibb               initial implementation      
+ *   David Knibb               initial implementation
  *   Matthew Webster           Eclipse 3.2 changes
- *   Martin Lippert            caching optimizations     
+ *   Martin Lippert            caching optimizations
  *   Martin Lippert            caching of generated classes
  *******************************************************************************/
 
@@ -29,7 +29,7 @@ import org.eclipse.osgi.storage.bundlefile.BundleFile;
 /**
  * This is a wrapper for bundle files that allows the weaving runtime to create
  * wrapped instances of bundle entry objects.
- * 
+ *
  * Those bundle entry objects are used to return class bytes from the cache
  * instead of the bundle itself.
  */
@@ -40,7 +40,7 @@ public class WeavingBundleFile extends AbstractWeavingBundleFile {
 
 	/**
 	 * Create a new wrapper for a bundle file
-	 * 
+	 *
 	 * @param adaptorProvider A provider that allows this wrapper to gain access to
 	 *                        the adaptor of this bundle
 	 * @param bundleFile      The wrapped bundle file

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,79 @@
               </ignores>
           </configuration>
       </plugin>
+	    <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-cleancode-plugin</artifactId>
+          <version>${tycho.version}</version>
+        <executions>
+            <execution>
+                <id>cleanups</id>
+                <configuration>
+                    <cleanUpProfile>
+                        <!-- Make inner classes static where possible-->
+                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
+                        <!-- Add missing annotations -->
+                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+                        <!-- Add missing '@Deprecated' annotations-->
+                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+                        <!-- Use 'final' where possible -->
+                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+                        <!-- Add final modifier to private fields -->
+                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+                        <!-- Replace deprecated calls with inlined content where possible -->
+                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+                        <!-- Convert control statement bodies to block -->
+                        <cleanup.use_blocks>true</cleanup.use_blocks>
+                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
+                        <!-- Use pattern matching for instanceof -->
+                        <cleanup.instanceof>true</cleanup.instanceof>
+                        <!-- Remove unnecessary array creation -->
+                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
+                        <!-- Remove unnecessary suppress warning tokens -->
+                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
+						<!-- Remove unnecessary whitespace-->
+                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
+                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
+                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
+                        <!-- Removes unused imports -->
+                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
+                        <cleanup.organize_imports>false</cleanup.organize_imports>
+                    </cleanUpProfile>
+                </configuration>
+            </execution>
+            <execution>
+                <id>quickfixes</id>
+                <configuration>
+                    <baselines>
+                         <repository>
+                             <url>${previous-release.baseline}</url>
+                         </repository>
+                    </baselines>
+                    <bundles>
+                        <bundle>org.eclipse.ui.ide.application</bundle>
+                    </bundles>
+                    <application>org.eclipse.ui.ide.workbench</application>
+                    <quickfixes>
+                        <quickfix>org.eclipse.jdt.ui</quickfix>
+                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
+                    </quickfixes>
+                </configuration>
+            </execution>
+            <execution>
+                <id>manifest</id>
+                <configuration>
+                    <calculateUses>true</calculateUses>
+                </configuration>
+            </execution>
+        </executions>
+          <configuration>
+                <local>true</local>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -268,81 +268,10 @@
                   <ignore>osgi/src/.*</ignore>
                   <ignore>felix/src_test/.*</ignore>
               </ignores>
+		  <calculateUses>true</calculateUses>
           </configuration>
       </plugin>
-	    <plugin>
-          <groupId>org.eclipse.tycho</groupId>
-          <artifactId>tycho-cleancode-plugin</artifactId>
-          <version>${tycho.version}</version>
-        <executions>
-            <execution>
-                <id>cleanups</id>
-                <configuration>
-                    <cleanUpProfile>
-                        <!-- Make inner classes static where possible-->
-                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
-                        <!-- Add missing annotations -->
-                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
-                        <!-- Add missing '@Deprecated' annotations-->
-                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
-                        <!-- Use 'final' where possible -->
-                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
-                        <!-- Add final modifier to private fields -->
-                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
-                        <!-- Replace deprecated calls with inlined content where possible -->
-                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
-                        <!-- Convert control statement bodies to block -->
-                        <cleanup.use_blocks>true</cleanup.use_blocks>
-                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
-                        <!-- Use pattern matching for instanceof -->
-                        <cleanup.instanceof>true</cleanup.instanceof>
-                        <!-- Remove unnecessary array creation -->
-                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
-                        <!-- Remove unnecessary suppress warning tokens -->
-                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
-						<!-- Remove unnecessary whitespace-->
-                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
-                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
-                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
-                        <!-- Removes unused imports -->
-                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
-                        <cleanup.organize_imports>false</cleanup.organize_imports>
-                    </cleanUpProfile>
-                </configuration>
-            </execution>
-            <execution>
-                <id>quickfixes</id>
-                <configuration>
-                    <baselines>
-                         <repository>
-                             <url>${previous-release.baseline}</url>
-                         </repository>
-                    </baselines>
-                    <bundles>
-                        <bundle>org.eclipse.ui.ide.application</bundle>
-                    </bundles>
-                    <application>org.eclipse.ui.ide.workbench</application>
-                    <quickfixes>
-                        <quickfix>org.eclipse.jdt.ui</quickfix>
-                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
-                    </quickfixes>
-                </configuration>
-            </execution>
-            <execution>
-                <id>manifest</id>
-                <configuration>
-                    <calculateUses>true</calculateUses>
-                </configuration>
-            </execution>
-        </executions>
-          <configuration>
-                <local>true</local>
-            </configuration>
-        </plugin>
+	    
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

