### PR TITLE
Clean Code for bundles/org.eclipse.osgi.services

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -4,15 +4,14 @@ concurrency:
     cancel-in-progress: true
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 2 * * *'
 
 jobs:
   clean-code:
-    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@master
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@add_manifest_cleanup_profile
     with:
       author: Eclipse Equinox Bot <equinox-bot@eclipse.org>
       do-quickfix: false
       do-cleanups: true
+      do-manifest: true
     secrets:
       token: ${{ secrets.EQUINOX_BOT_PAT }}

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Activate.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Activate.java
@@ -24,15 +24,15 @@ import java.lang.annotation.Target;
 /**
  * Identify the annotated method as the {@code activate} method of a Service
  * Component.
- * 
+ *
  * <p>
  * The annotated method is the activate method of the Component.
- * 
+ *
  * <p>
  * This annotation is not processed at runtime by Service Component Runtime. It
  * must be processed by tools and used to add a Component Description to the
  * bundle.
- * 
+ *
  * @see "The activate attribute of the component element of a Component Description."
  * @author $Id$
  * @since 1.1

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Component.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Component.java
@@ -23,15 +23,15 @@ import java.lang.annotation.Target;
 
 /**
  * Identify the annotated class as a Service Component.
- * 
+ *
  * <p>
  * The annotated class is the implementation class of the Component.
- * 
+ *
  * <p>
  * This annotation is not processed at runtime by Service Component Runtime. It
  * must be processed by tools and used to add a Component Description to the
  * bundle.
- * 
+ *
  * @see "The component element of a Component Description."
  * @author $Id$
  */
@@ -40,26 +40,26 @@ import java.lang.annotation.Target;
 public @interface Component {
 	/**
 	 * The name of this Component.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the name of this Component is the fully qualified type
 	 * name of the class being annotated.
-	 * 
+	 *
 	 * @see "The name attribute of the component element of a Component Description."
 	 */
 	String name() default "";
 
 	/**
 	 * The types under which to register this Component as a service.
-	 * 
+	 *
 	 * <p>
 	 * If no service should be registered, the empty value
 	 * <code>&#x7B;&#x7D;</code> must be specified.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the service types for this Component are all the
 	 * <i>directly</i> implemented interfaces of the class being annotated.
-	 * 
+	 *
 	 * @see "The service element of a Component Description."
 	 */
 	Class<?>[] service() default {};
@@ -67,11 +67,11 @@ public @interface Component {
 	/**
 	 * The factory identifier of this Component. Specifying a factory identifier
 	 * makes this Component a Factory Component.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the default is that this Component is not a Factory
 	 * Component.
-	 * 
+	 *
 	 * @see "The factory attribute of the component element of a Component Description."
 	 */
 	String factory() default "";
@@ -80,7 +80,7 @@ public @interface Component {
 	 * Declares whether this Component uses the OSGi ServiceFactory concept and
 	 * each bundle using this Component's service will receive a different
 	 * component instance.
-	 * 
+	 *
 	 * <p>
 	 * This element is ignored when the {@link #scope()} element does not have
 	 * the default value. If {@code true}, this Component uses
@@ -89,7 +89,7 @@ public @interface Component {
 	 * service scope. If the {@link #factory()} element is specified or the
 	 * {@link #immediate()} element is specified with {@code true}, this element
 	 * can only be specified with {@code false}.
-	 * 
+	 *
 	 * @see "The scope attribute of the service element of a Component Description."
 	 * @deprecated Since 1.3. Replaced by {@link #scope()}.
 	 */
@@ -98,11 +98,11 @@ public @interface Component {
 	/**
 	 * Declares whether this Component is enabled when the bundle containing it
 	 * is started.
-	 * 
+	 *
 	 * <p>
 	 * If {@code true} or not specified, this Component is enabled. If
 	 * {@code false}, this Component is disabled.
-	 * 
+	 *
 	 * @see "The enabled attribute of the component element of a Component Description."
 	 */
 	boolean enabled() default true;
@@ -110,7 +110,7 @@ public @interface Component {
 	/**
 	 * Declares whether this Component must be immediately activated upon
 	 * becoming satisfied or whether activation should be delayed.
-	 * 
+	 *
 	 * <p>
 	 * If {@code true}, this Component must be immediately activated upon
 	 * becoming satisfied. If {@code false}, activation of this Component is
@@ -118,67 +118,67 @@ public @interface Component {
 	 * if the {@link #factory()} property is also specified or must be
 	 * {@code true} if the {@link #service()} property is specified with an
 	 * empty value.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the default is {@code false} if the {@link #factory()}
 	 * property is specified or the {@link #service()} property is not specified
 	 * or specified with a non-empty value and {@code true} otherwise.
-	 * 
+	 *
 	 * @see "The immediate attribute of the component element of a Component Description."
 	 */
 	boolean immediate() default false;
 
 	/**
 	 * Properties for this Component.
-	 * 
+	 *
 	 * <p>
 	 * Each property string is specified as {@code "name=value"}. The type of
 	 * the property value can be specified in the name as
 	 * {@code name:type=value}. The type must be one of the property types
 	 * supported by the type attribute of the property element of a Component
 	 * Description.
-	 * 
+	 *
 	 * <p>
 	 * To specify a property with multiple values, use multiple name, value
 	 * pairs. For example, {@code "foo=bar", "foo=baz"}.
-	 * 
+	 *
 	 * @see "The property element of a Component Description."
 	 */
 	String[] property() default {};
 
 	/**
 	 * Property entries for this Component.
-	 * 
+	 *
 	 * <p>
 	 * Specifies the name of an entry in the bundle whose contents conform to a
 	 * standard Java Properties File. The entry is read and processed to obtain
 	 * the properties and their values.
-	 * 
+	 *
 	 * @see "The properties element of a Component Description."
 	 */
 	String[] properties() default {};
 
 	/**
 	 * The XML name space of the Component Description for this Component.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the XML name space of the Component Description for
 	 * this Component should be the lowest Declarative Services XML name space
 	 * which supports all the specification features used by this Component.
-	 * 
+	 *
 	 * @see "The XML name space specified for a Component Description."
 	 */
 	String xmlns() default "";
 
 	/**
 	 * The configuration policy of this Component.
-	 * 
+	 *
 	 * <p>
 	 * Controls whether component configurations must be satisfied depending on
 	 * the presence of a corresponding Configuration object in the OSGi
 	 * Configuration Admin service. A corresponding configuration is a
 	 * Configuration object where the PID equals the name of the component.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the configuration policy is based upon whether the
 	 * component is also annotated with the Meta Type
@@ -192,7 +192,7 @@ public @interface Component {
 	 * <li>Annotated with {@code Designate(factory=true)} - The configuration
 	 * policy is {@link ConfigurationPolicy#REQUIRE REQUIRE}.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The configuration-policy attribute of the component element of a Component Description."
 	 * @since 1.1
 	 */
@@ -200,26 +200,26 @@ public @interface Component {
 
 	/**
 	 * The configuration PIDs for the configuration of this Component.
-	 * 
+	 *
 	 * <p>
 	 * Each value specifies a configuration PID for this Component.
-	 * 
+	 *
 	 * <p>
 	 * If no value is specified, the name of this Component is used as the
 	 * configuration PID of this Component.
-	 * 
+	 *
 	 * <p>
 	 * A special string (<code>{@value #NAME}</code>) can be used to specify the
 	 * name of the component as a configuration PID. The {@code NAME} constant
 	 * holds this special string. For example:
-	 * 
+	 *
 	 * <pre>
 	 * &#64;Component(configurationPid={"com.acme.system", Component.NAME})
 	 * </pre>
-	 * 
+	 *
 	 * Tools creating a Component Description from this annotation must replace
 	 * the special string with the actual name of this Component.
-	 * 
+	 *
 	 * @see "The configuration-pid attribute of the component element of a Component Description."
 	 * @since 1.2
 	 */
@@ -227,25 +227,25 @@ public @interface Component {
 
 	/**
 	 * Special string representing the name of this Component.
-	 * 
+	 *
 	 * <p>
 	 * This string can be used in {@link #configurationPid()} to specify the
 	 * name of the component as a configuration PID. For example:
-	 * 
+	 *
 	 * <pre>
 	 * &#64;Component(configurationPid={"com.acme.system", Component.NAME})
 	 * </pre>
-	 * 
+	 *
 	 * Tools creating a Component Description from this annotation must replace
 	 * the special string with the actual name of this Component.
-	 * 
+	 *
 	 * @since 1.3
 	 */
 	String	NAME	= "$";
 
 	/**
 	 * The service scope for the service of this Component.
-	 * 
+	 *
 	 * <p>
 	 * If not specified (and the deprecated {@link #servicefactory()} element is
 	 * not specified), the {@link ServiceScope#SINGLETON singleton} service
@@ -253,7 +253,7 @@ public @interface Component {
 	 * {@link #immediate()} element is specified with {@code true}, this element
 	 * can only be specified with the {@link ServiceScope#SINGLETON singleton}
 	 * service scope.
-	 * 
+	 *
 	 * @see "The scope attribute of the service element of a Component Description."
 	 * @since 1.3
 	 */
@@ -261,18 +261,18 @@ public @interface Component {
 
 	/**
 	 * The lookup strategy references of this Component.
-	 * 
+	 *
 	 * <p>
 	 * To access references using the lookup strategy, {@link Reference}
 	 * annotations are specified naming the reference and declaring the type of
 	 * the referenced service. The referenced service can be accessed using one
 	 * of the {@code locateService} methods of {@code ComponentContext}.
-	 * 
+	 *
 	 * <p>
 	 * To access references using the event strategy, bind methods are annotated
 	 * with {@link Reference}. To access references using the field strategy,
 	 * fields are annotated with {@link Reference}.
-	 * 
+	 *
 	 * @see "The reference element of a Component Description."
 	 * @since 1.3
 	 */

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ConfigurationPolicy.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ConfigurationPolicy.java
@@ -18,13 +18,13 @@ package org.osgi.service.component.annotations;
 
 /**
  * Configuration Policy for the {@link Component} annotation.
- * 
+ *
  * <p>
  * Controls whether component configurations must be satisfied depending on the
  * presence of a corresponding Configuration object in the OSGi Configuration
  * Admin service. A corresponding configuration is a Configuration object where
  * the PID is the name of the component.
- * 
+ *
  * @author $Id$
  * @since 1.1
  */

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Deactivate.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Deactivate.java
@@ -24,15 +24,15 @@ import java.lang.annotation.Target;
 /**
  * Identify the annotated method as the {@code deactivate} method of a Service
  * Component.
- * 
+ *
  * <p>
  * The annotated method is the deactivate method of the Component.
- * 
+ *
  * <p>
  * This annotation is not processed at runtime by Service Component Runtime. It
  * must be processed by tools and used to add a Component Description to the
  * bundle.
- * 
+ *
  * @see "The deactivate attribute of the component element of a Component Description."
  * @author $Id$
  * @since 1.1

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/FieldOption.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/FieldOption.java
@@ -18,22 +18,22 @@ package org.osgi.service.component.annotations;
 
 /**
  * Field options for the {@link Reference} annotation.
- * 
+ *
  * @since 1.3
  * @author $Id$
  */
 public enum FieldOption {
-	
+
 	/**
 	 * The update field option is used to update the collection referenced by
 	 * the field when there are changes to the bound services.
-	 * 
+	 *
 	 * <p>
 	 * This field option can only be used when the field reference has dynamic
 	 * policy and multiple cardinality.
 	 */
 	UPDATE("update"),
-	
+
 	/**
 	 * The replace field option is used to replace the field value with a new
 	 * value when there are changes to the bound services.

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Modified.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Modified.java
@@ -24,15 +24,15 @@ import java.lang.annotation.Target;
 /**
  * Identify the annotated method as the {@code modified} method of a Service
  * Component.
- * 
+ *
  * <p>
  * The annotated method is the modified method of the Component.
- * 
+ *
  * <p>
  * This annotation is not processed at runtime by Service Component Runtime. It
  * must be processed by tools and used to add a Component Description to the
  * bundle.
- * 
+ *
  * @see "The modified attribute of the component element of a Component Description."
  * @author $Id$
  * @since 1.1

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Reference.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/Reference.java
@@ -23,22 +23,22 @@ import java.lang.annotation.Target;
 
 /**
  * Identify the annotated member as a reference of a Service Component.
- * 
+ *
  * <p>
  * When the annotation is applied to a method, the method is the bind method of
  * the reference. When the annotation is applied to a field, the field will
  * contain the bound service(s) of the reference.
- * 
+ *
  * <p>
  * This annotation is not processed at runtime by Service Component Runtime. It
  * must be processed by tools and used to add a Component Description to the
  * bundle.
- * 
+ *
  * <p>
  * In the generated Component Description for a component, the references must
  * be ordered in ascending lexicographical order (using {@code String.compareTo}
  * ) of the reference {@link #name() name}s.
- * 
+ *
  * @see "The reference element of a Component Description."
  * @author $Id$
  */
@@ -47,12 +47,12 @@ import java.lang.annotation.Target;
 public @interface Reference {
 	/**
 	 * The name of this reference.
-	 * 
+	 *
 	 * <p>
 	 * The name of this reference must be specified when using this annotation
 	 * in the {@link Component#reference()} element since there is no annotated
 	 * member from which the name can be determined.
-	 * 
+	 *
 	 * If not specified, the name of this reference is based upon how this
 	 * annotation is used:
 	 * <ul>
@@ -61,20 +61,20 @@ public @interface Reference {
 	 * the reference. Otherwise, the name of the reference is the method name.</li>
 	 * <li>Annotated field - The name of the reference is the field name.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The name attribute of the reference element of a Component Description."
 	 */
 	String name() default "";
 
 	/**
 	 * The type of the service for this reference.
-	 * 
+	 *
 	 * <p>
 	 * The type of the service for this reference must be specified when using
 	 * this annotation in the {@link Component#reference()} element since there
 	 * is no annotated member from which the type of the service can be
 	 * determined.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the type of the service for this reference is based
 	 * upon how this annotation is used:
@@ -90,14 +90,14 @@ public @interface Reference {
 	 * generic type of the collection. Otherwise, the type of the service is the
 	 * type of the field.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The interface attribute of the reference element of a Component Description."
 	 */
 	Class<?> service() default Object.class;
 
 	/**
 	 * The cardinality of this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the cardinality of this reference is based upon how
 	 * this annotation is used:
@@ -112,14 +112,14 @@ public @interface Reference {
 	 * <li>{@link Component#reference()} element - The cardinality is
 	 * {@link ReferenceCardinality#MANDATORY 1..1}.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The cardinality attribute of the reference element of a Component Description."
 	 */
 	ReferenceCardinality cardinality() default ReferenceCardinality.MANDATORY;
 
 	/**
 	 * The policy for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the policy of this reference is based upon how this
 	 * annotation is used:
@@ -133,28 +133,28 @@ public @interface Reference {
 	 * <li>{@link Component#reference()} element - The policy is
 	 * {@link ReferencePolicy#STATIC STATIC}.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The policy attribute of the reference element of a Component Description."
 	 */
 	ReferencePolicy policy() default ReferencePolicy.STATIC;
 
 	/**
 	 * The target property for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, no target property is set.
-	 * 
+	 *
 	 * @see "The target attribute of the reference element of a Component Description."
 	 */
 	String target() default "";
 
 	/**
 	 * The policy option for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the {@link ReferencePolicyOption#RELUCTANT RELUCTANT}
 	 * reference policy option is used.
-	 * 
+	 *
 	 * @see "The policy-option attribute of the reference element of a Component Description."
 	 * @since 1.2
 	 */
@@ -162,11 +162,11 @@ public @interface Reference {
 
 	/**
 	 * The reference scope for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the {@link ReferenceScope#BUNDLE bundle} reference
 	 * scope is used.
-	 * 
+	 *
 	 * @see "The scope attribute of the reference element of a Component Description."
 	 * @since 1.3
 	 */
@@ -176,11 +176,11 @@ public @interface Reference {
 
 	/**
 	 * The name of the bind method for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If specified and this reference annotates a method, the specified name
 	 * must match the name of the annotated method.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the name of the bind method is based upon how this
 	 * annotation is used:
@@ -191,11 +191,11 @@ public @interface Reference {
 	 * <li>{@link Component#reference()} element - There is no bind method name.
 	 * </li>
 	 * </ul>
-	 * 
+	 *
 	 * <p>
 	 * If there is a bind method name, the component must contain a method with
 	 * that name.
-	 * 
+	 *
 	 * @see "The bind attribute of the reference element of a Component Description."
 	 * @since 1.3
 	 */
@@ -203,7 +203,7 @@ public @interface Reference {
 
 	/**
 	 * The name of the updated method for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the name of the updated method is based upon how this
 	 * annotation is used:
@@ -222,11 +222,11 @@ public @interface Reference {
 	 * <li>{@link Component#reference()} element - There is no updated method
 	 * name.</li>
 	 * </ul>
-	 * 
+	 *
 	 * <p>
 	 * If there is an updated method name, the component must contain a method
 	 * with that name.
-	 * 
+	 *
 	 * @see "The updated attribute of the reference element of a Component Description."
 	 * @since 1.2
 	 */
@@ -234,7 +234,7 @@ public @interface Reference {
 
 	/**
 	 * The name of the unbind method for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the name of the unbind method is based upon how this
 	 * annotation is used:
@@ -253,11 +253,11 @@ public @interface Reference {
 	 * <li>{@link Component#reference()} element - There is no unbind method
 	 * name.</li>
 	 * </ul>
-	 * 
+	 *
 	 * <p>
 	 * If there is an unbind method name, the component must contain a method
 	 * with that name.
-	 * 
+	 *
 	 * @see "The unbind attribute of the reference element of a Component Description."
 	 */
 	String unbind() default "";
@@ -266,11 +266,11 @@ public @interface Reference {
 
 	/**
 	 * The name of the field for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If specified and this reference annotates a field, the specified name
 	 * must match the name of the annotated field.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the name of the field is based upon how this annotation
 	 * is used:
@@ -280,11 +280,11 @@ public @interface Reference {
 	 * field.</li>
 	 * <li>{@link Component#reference()} element - There is no field name.</li>
 	 * </ul>
-	 * 
+	 *
 	 * <p>
 	 * If there is a field name, the component must contain a field with that
 	 * name.
-	 * 
+	 *
 	 * @see "The field attribute of the reference element of a Component Description."
 	 * @since 1.3
 	 */
@@ -292,7 +292,7 @@ public @interface Reference {
 
 	/**
 	 * The field option for this reference.
-	 * 
+	 *
 	 * <p>
 	 * If not specified, the field option is based upon how this annotation is
 	 * used:
@@ -307,7 +307,7 @@ public @interface Reference {
 	 * the field option is {@link FieldOption#REPLACE}</li>
 	 * <li>{@link Component#reference()} element - There is no field option.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @see "The field-option attribute of the reference element of a Component Description."
 	 * @since 1.3
 	 */

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferenceCardinality.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferenceCardinality.java
@@ -18,11 +18,11 @@ package org.osgi.service.component.annotations;
 
 /**
  * Cardinality for the {@link Reference} annotation.
- * 
+ *
  * <p>
  * Specifies if the reference is optional and if the component implementation
  * support a single bound service or multiple bound services.
- * 
+ *
  * @author $Id$
  */
 public enum ReferenceCardinality {

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferencePolicy.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferencePolicy.java
@@ -18,7 +18,7 @@ package org.osgi.service.component.annotations;
 
 /**
  * Policy for the {@link Reference} annotation.
- * 
+ *
  * @author $Id$
  */
 public enum ReferencePolicy {

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferencePolicyOption.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferencePolicyOption.java
@@ -18,7 +18,7 @@ package org.osgi.service.component.annotations;
 
 /**
  * Policy option for the {@link Reference} annotation.
- * 
+ *
  * @author $Id$
  * @since 1.2
  */

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferenceScope.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ReferenceScope.java
@@ -18,7 +18,7 @@ package org.osgi.service.component.annotations;
 
 /**
  * Reference scope for the {@link Reference} annotation.
- * 
+ *
  * @author $Id$
  * @since 1.3
  */

--- a/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ServiceScope.java
+++ b/bundles/org.eclipse.osgi.services/src/org/osgi/service/component/annotations/ServiceScope.java
@@ -18,7 +18,7 @@ package org.osgi.service.component.annotations;
 
 /**
  * Service scope for the {@link Component} annotation.
- * 
+ *
  * @author $Id$
  * @since 1.3
  */

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,79 @@
               </ignores>
           </configuration>
       </plugin>
+	    <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-cleancode-plugin</artifactId>
+          <version>${tycho.version}</version>
+        <executions>
+            <execution>
+                <id>cleanups</id>
+                <configuration>
+                    <cleanUpProfile>
+                        <!-- Make inner classes static where possible-->
+                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
+                        <!-- Add missing annotations -->
+                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
+                        <!-- Add missing '@Deprecated' annotations-->
+                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
+                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
+                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
+                        <!-- Use 'final' where possible -->
+                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
+                        <!-- Add final modifier to private fields -->
+                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
+                        <!-- Replace deprecated calls with inlined content where possible -->
+                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
+                        <!-- Convert control statement bodies to block -->
+                        <cleanup.use_blocks>true</cleanup.use_blocks>
+                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
+                        <!-- Use pattern matching for instanceof -->
+                        <cleanup.instanceof>true</cleanup.instanceof>
+                        <!-- Remove unnecessary array creation -->
+                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
+                        <!-- Remove unnecessary suppress warning tokens -->
+                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
+						<!-- Remove unnecessary whitespace-->
+                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
+                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
+                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
+                        <!-- Removes unused imports -->
+                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
+                        <cleanup.organize_imports>false</cleanup.organize_imports>
+                    </cleanUpProfile>
+                </configuration>
+            </execution>
+            <execution>
+                <id>quickfixes</id>
+                <configuration>
+                    <baselines>
+                         <repository>
+                             <url>${previous-release.baseline}</url>
+                         </repository>
+                    </baselines>
+                    <bundles>
+                        <bundle>org.eclipse.ui.ide.application</bundle>
+                    </bundles>
+                    <application>org.eclipse.ui.ide.workbench</application>
+                    <quickfixes>
+                        <quickfix>org.eclipse.jdt.ui</quickfix>
+                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
+                    </quickfixes>
+                </configuration>
+            </execution>
+            <execution>
+                <id>manifest</id>
+                <configuration>
+                    <calculateUses>true</calculateUses>
+                </configuration>
+            </execution>
+        </executions>
+          <configuration>
+                <local>true</local>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -268,81 +268,10 @@
                   <ignore>osgi/src/.*</ignore>
                   <ignore>felix/src_test/.*</ignore>
               </ignores>
+		  <calculateUses>true</calculateUses>
           </configuration>
       </plugin>
-	    <plugin>
-          <groupId>org.eclipse.tycho</groupId>
-          <artifactId>tycho-cleancode-plugin</artifactId>
-          <version>${tycho.version}</version>
-        <executions>
-            <execution>
-                <id>cleanups</id>
-                <configuration>
-                    <cleanUpProfile>
-                        <!-- Make inner classes static where possible-->
-                        <cleanup.static_inner_class>true</cleanup.static_inner_class>
-                        <!-- Add missing annotations -->
-                        <cleanup.add_missing_annotations>true</cleanup.add_missing_annotations>
-                        <!-- Add missing '@Deprecated' annotations-->
-                        <cleanup.add_missing_deprecated_annotations>true</cleanup.add_missing_deprecated_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations>true</cleanup.add_missing_override_annotations>
-                        <!-- Add missing '@Override' annotations to implementations of interface methods -->
-                        <cleanup.add_missing_override_annotations_interface_methods>true</cleanup.add_missing_override_annotations_interface_methods>
-                        <!-- Use 'final' where possible -->
-                        <cleanup.make_variable_declarations_final>true</cleanup.make_variable_declarations_final>
-                        <!-- Add final modifier to private fields -->
-                        <cleanup.make_private_fields_final>true</cleanup.make_private_fields_final>
-                        <!-- Replace deprecated calls with inlined content where possible -->
-                        <cleanup.replace_deprecated_calls>true</cleanup.replace_deprecated_calls>
-                        <!-- Convert control statement bodies to block -->
-                        <cleanup.use_blocks>true</cleanup.use_blocks>
-                        <cleanup.always_use_blocks>true</cleanup.always_use_blocks>
-                        <!-- Use pattern matching for instanceof -->
-                        <cleanup.instanceof>true</cleanup.instanceof>
-                        <!-- Remove unnecessary array creation -->
-                        <cleanup.remove_unnecessary_array_creation>true</cleanup.remove_unnecessary_array_creation>
-                        <!-- Remove unnecessary suppress warning tokens -->
-                        <cleanup.remove_unnecessary_suppress_warnings>true</cleanup.remove_unnecessary_suppress_warnings>
-						<!-- Remove unnecessary whitespace-->
-                        <cleanup.remove_trailing_whitespaces>true</cleanup.remove_trailing_whitespaces>
-                        <cleanup.remove_trailing_whitespaces_all>true</cleanup.remove_trailing_whitespaces_all>
-                        <cleanup.remove_trailing_whitespaces_ignore_empty>false</cleanup.remove_trailing_whitespaces_ignore_empty>
-                        <!-- Removes unused imports -->
-                        <cleanup.remove_unused_imports>true</cleanup.remove_unused_imports>
-                        <cleanup.organize_imports>false</cleanup.organize_imports>
-                    </cleanUpProfile>
-                </configuration>
-            </execution>
-            <execution>
-                <id>quickfixes</id>
-                <configuration>
-                    <baselines>
-                         <repository>
-                             <url>${previous-release.baseline}</url>
-                         </repository>
-                    </baselines>
-                    <bundles>
-                        <bundle>org.eclipse.ui.ide.application</bundle>
-                    </bundles>
-                    <application>org.eclipse.ui.ide.workbench</application>
-                    <quickfixes>
-                        <quickfix>org.eclipse.jdt.ui</quickfix>
-                        <quickfix>org.eclipse.pde.api.tools.ui</quickfix>
-                    </quickfixes>
-                </configuration>
-            </execution>
-            <execution>
-                <id>manifest</id>
-                <configuration>
-                    <calculateUses>true</calculateUses>
-                </configuration>
-            </execution>
-        </executions>
-          <configuration>
-                <local>true</local>
-            </configuration>
-        </plugin>
+	    
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

