### PR TITLE
Clean Code for bundles/org.eclipse.equinox.common

### DIFF
--- a/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.common/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Export-Package: org.eclipse.core.internal.boot;x-friends:="org.eclipse.core.reso
    org.eclipse.core.runtime.compatibility,
    org.eclipse.core.filesystem,
    org.eclipse.equinox.security",
- org.eclipse.core.runtime;common=split;version="3.7.0";mandatory:=common,
+ org.eclipse.core.runtime;common=split;version="3.7.0";mandatory:=common;uses:="org.osgi.framework",
  org.eclipse.core.text;version="3.14.0",
  org.eclipse.equinox.events;version="1.0.0"
 Bundle-Vendor: %providerName

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLBaseConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLBaseConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -321,7 +321,7 @@ public abstract class PlatformURLConnection extends URLConnection {
 
 	/*
 	 * to be implemented by subclass
-	 * 
+	 *
 	 * @return URL resolved URL
 	 */
 	protected URL resolve() throws IOException {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLHandler.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/boot/PlatformURLHandler.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/Activator.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/Activator.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -37,7 +37,7 @@ import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The Common runtime plugin class.
- * 
+ *
  * This class can only be used if OSGi plugin is available.
  */
 public class Activator implements BundleActivator {
@@ -153,7 +153,7 @@ public class Activator implements BundleActivator {
 
 	/**
 	 * Return the resolved bundle with the specified symbolic name.
-	 * 
+	 *
 	 * @see PackageAdmin#getBundles(String, String)
 	 */
 	public Bundle getBundle(String symbolicName) {
@@ -217,7 +217,7 @@ public class Activator implements BundleActivator {
 	/**
 	 * Returns the resource bundle responsible for location of the given bundle in
 	 * the given locale. Does not return null.
-	 * 
+	 *
 	 * @throws MissingResourceException If the corresponding resource could not be
 	 *                                  found
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/AdapterFactoryBridge.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/AdapterFactoryBridge.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Christoph Laeubrich - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/AdapterManager.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/AdapterManager.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *     David Green - fix factories with non-standard class loading (bug 200068) 
+ *     David Green - fix factories with non-standard class loading (bug 200068)
  *     Filip Hrbek - fix thread safety problem described in bug 305863
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
  *     Christoph Läubrich - Bug 576660 - AdapterManager should use more modern concurrency primitives
@@ -42,7 +42,7 @@ import org.eclipse.core.runtime.*;
  * then Y's superinterfaces)</li>
  * </ul>
  * </ul>
- * 
+ *
  * @see IAdapterFactory
  * @see IAdapterManager
  */
@@ -131,7 +131,7 @@ public final class AdapterManager implements IAdapterManager {
 	/**
 	 * Queries an {@link IAdapterFactory} for a given type name to return a
 	 * compatible class object
-	 * 
+	 *
 	 * @param adapterFactory the {@link IAdapterFactory} to query for the given
 	 *                       classname, must not be <code>null</code>
 	 * @param typeName       the name of the desired class, must not be
@@ -289,7 +289,7 @@ public final class AdapterManager implements IAdapterManager {
 
 	/**
 	 * Returns an adapter of the given type for the provided adapter.
-	 * 
+	 *
 	 * @param adaptable   the object to adapt
 	 * @param adapterType the type to adapt the object to
 	 * @param force       <code>true</code> if the plug-in providing the factory
@@ -410,7 +410,7 @@ public final class AdapterManager implements IAdapterManager {
 
 	/**
 	 * Try to load the given factory according to the force parameter
-	 * 
+	 *
 	 * @param factory the factory to load
 	 * @param force   if loading should be forced
 	 * @return an {@link Optional} describing the loaded factory

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DevClassPathHelper.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/DevClassPathHelper.java
@@ -65,7 +65,7 @@ public class DevClassPathHelper {
 	/**
 	 * Returns the result of converting a list of comma-separated tokens into an
 	 * array
-	 * 
+	 *
 	 * @return the array of string tokens
 	 * @param prop the initial comma-separated string
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IAdapterFactoryExt.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IAdapterFactoryExt.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ public interface IAdapterFactoryExt {
 	/**
 	 * Loads the real adapter factory, but only if its associated plug-in is already
 	 * loaded. Returns the real factory if it was successfully loaded.
-	 * 
+	 *
 	 * @param force if <code>true</code> the plugin providing the factory will be
 	 *              loaded if necessary, otherwise no plugin activations will occur.
 	 * @return the adapter factory, or <code>null</code>

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IAdapterManagerProvider.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IAdapterManagerProvider.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,7 @@ package org.eclipse.core.internal.runtime;
 /**
  * The callback interface for the elements desiring to lazily supply information
  * to the adapter manager.
- * 
+ *
  * @since org.eclipse.core.runtime 3.2
  */
 public interface IAdapterManagerProvider {
@@ -24,7 +24,7 @@ public interface IAdapterManagerProvider {
 	/**
 	 * Add factories. The method called before the AdapterManager starts using
 	 * factories.
-	 * 
+	 *
 	 * @param adapterManager the adapter manager that is about to be used
 	 * @return <code>true</code> if factories were added; <code>false</code> if no
 	 *         factories were added in this method call.

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IRuntimeConstants.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/IRuntimeConstants.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/LocalizationUtils.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/LocalizationUtils.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Field;
 
 /**
  * Helper methods related to string localization.
- * 
+ *
  * @since org.eclipse.equinox.common 3.3
  */
 public class LocalizationUtils {
@@ -26,7 +26,7 @@ public class LocalizationUtils {
 	 * This method can be used in the absence of NLS class. The method tries to use
 	 * the NLS-based translation routine. If it falls, the method returns the
 	 * original non-translated key.
-	 * 
+	 *
 	 * @param key case-sensitive name of the filed in the translation file
 	 *            representing the string to be translated
 	 * @return The localized message or the non-translated key

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/MetaDataKeeper.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/MetaDataKeeper.java
@@ -16,9 +16,9 @@ package org.eclipse.core.internal.runtime;
 /**
  * The class contains a set of utilities working platform metadata area. This
  * class can only be used if OSGi plugin is available.
- * 
+ *
  * Copied from InternalPlatform as of August 30, 2005.
- * 
+ *
  * @since org.eclipse.equinox.common 3.2
  */
 public class MetaDataKeeper {
@@ -28,7 +28,7 @@ public class MetaDataKeeper {
 	/**
 	 * Returns the object which defines the location and organization of the
 	 * platform's meta area.
-	 * 
+	 *
 	 * @return non null
 	 */
 	public static synchronized DataArea getMetaArea() {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformLogWriter.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformLogWriter.java
@@ -7,7 +7,7 @@
  *  https://www.eclipse.org/legal/epl-2.0/
  *
  *  SPDX-License-Identifier: EPL-2.0
- * 
+ *
  *  Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConfigConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConfigConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConverter.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLConverter.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -24,7 +24,7 @@ import org.eclipse.osgi.service.urlconversion.URLConverter;
 /**
  * Class which implements the URLConverter service. Manages conversion of a
  * platform: URL to one with a more well known protocol.
- * 
+ *
  * @since 3.2
  */
 public class PlatformURLConverter implements URLConverter {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLFragmentConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLFragmentConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLMetaConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLMetaConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLPluginConnection.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PlatformURLPluginConnection.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PrintStackUtil.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/PrintStackUtil.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ReferenceHashSet.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/ReferenceHashSet.java
@@ -19,7 +19,7 @@ import java.lang.ref.*;
 /**
  * A hashset whose values can be garbage collected. This API is EXPERIMENTAL and
  * provided as early access.
- * 
+ *
  * @since 3.1
  */
 public class ReferenceHashSet<T> {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/RuntimeLog.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/internal/runtime/RuntimeLog.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Julian Chen - fix for bug #92572, jclRM
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.*;
 
 /**
  * NOT API!!! This log infrastructure was split from the InternalPlatform.
- * 
+ *
  * @since org.eclipse.equinox.common 3.2
  */
 public final class RuntimeLog {
@@ -121,7 +121,7 @@ public final class RuntimeLog {
 
 	/**
 	 * Helps determine if the logging mechanism is ready for logging.
-	 * 
+	 *
 	 * @return true the logging mechanism is ready for logging.
 	 */
 	public static boolean isEmpty() {
@@ -132,7 +132,7 @@ public final class RuntimeLog {
 
 	/**
 	 * Determines if there are any listeners
-	 * 
+	 *
 	 * @return true if there is at least one listener.
 	 */
 	public static boolean hasListeners() {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AdapterTypes.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AdapterTypes.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
  *******************************************************************************/
@@ -19,13 +19,13 @@ import org.osgi.service.component.annotations.ComponentPropertyType;
 /**
  * Annotation that can be used for components to specify the provided adapter
  * types. example use case
- * 
+ *
  * <pre>
- * 
+ *
  * &#64;Component
  * &#64;AdapterTypes(adaptableClass = Template.class, adapterNames = { ILabelProvider.class, IContentProvider.class })
  * public class TemplateAdapter implements IAdapterFactory {
- * 
+ *
  *     &#64;Override
  *     public &lt;T&gt; T getAdapter(Object adaptableObject, Class&lt;T&gt; adapterType) {
  *         if (adaptableObject instanceof Template template) {
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.ComponentPropertyType;
  *     }
  * }
  * </pre>
- * 
+ *
  * @since 3.19
  */
 @ComponentPropertyType
@@ -44,14 +44,14 @@ import org.osgi.service.component.annotations.ComponentPropertyType;
 public @interface AdapterTypes {
 	/**
 	 * See {@link IAdapterFactory#SERVICE_PROPERTY_ADAPTABLE_CLASS}
-	 * 
+	 *
 	 * @return the types that this class adapts from
 	 */
 	Class<?>[] adaptableClass();
 
 	/**
 	 * See {@link IAdapterFactory#SERVICE_PROPERTY_ADAPTER_NAMES}
-	 * 
+	 *
 	 * @return the types that this class adapts to
 	 */
 	Class<?>[] adapterNames();

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Adapters.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 478685, 478864, 479849
@@ -22,7 +22,7 @@ import org.eclipse.osgi.util.NLS;
 
 /**
  * Provides a standard way to request adapters from adaptable objects
- * 
+ *
  * @see IAdaptable
  * @see IAdapterManager
  * @since 3.8
@@ -31,16 +31,16 @@ public class Adapters {
 	/**
 	 * If it is possible to adapt the given object to the given type, this returns
 	 * the adapter. Performs the following checks:
-	 * 
+	 *
 	 * <ol>
 	 * <li>Returns <code>sourceObject</code> if it is an instance of the adapter
 	 * type.</li>
 	 * <li>If sourceObject implements IAdaptable, it is queried for adapters.</li>
 	 * <li>Finally, the adapter manager is consulted for adapters</li>
 	 * </ol>
-	 * 
+	 *
 	 * Otherwise returns null.
-	 * 
+	 *
 	 * @param <T>             class type to adapt to
 	 * @param sourceObject    object to adapt, can be null
 	 * @param adapter         type to adapt to
@@ -102,7 +102,7 @@ public class Adapters {
 	 * Convenience method for calling <code>adapt(Object, Class, true)</code>.
 	 * <p>
 	 * See {@link #adapt(Object, Class, boolean)}.
-	 * 
+	 *
 	 * @param <T>          class type to adapt to
 	 * @param sourceObject object to adapt, can be null
 	 * @param adapter      type to adapt to
@@ -117,7 +117,7 @@ public class Adapters {
 	 * If it is possible to adapt the given object to the given type, this returns
 	 * an optional holding the adapter, in all other cases it returns an empty
 	 * optional.
-	 * 
+	 *
 	 * @param sourceObject object to adapt, if <code>null</code> then
 	 *                     {@link Optional#empty()} is returned
 	 * @param adapter      type to adapt to, must not be <code>null</code>

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Assert.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Assert.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -29,7 +29,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This class is not intended to be instantiated or sub-classed by clients.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.common 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
@@ -73,7 +73,7 @@ public final class Assert {
 	/**
 	 * Asserts that the given object is not <code>null</code>. If this is not the
 	 * case, some kind of unchecked exception is thrown.
-	 * 
+	 *
 	 * @param object the value to test
 	 */
 	public static void isNotNull(Object object) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AssertionFailedException.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/AssertionFailedException.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -22,7 +22,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This class is not intended to be instantiated or sub-classed by clients.
  * </p>
- * 
+ *
  * @see Assert
  * @since org.eclipse.equinox.common 3.2
  * @noextend This class is not intended to be subclassed by clients.
@@ -37,7 +37,7 @@ public class AssertionFailedException extends RuntimeException {
 
 	/**
 	 * Constructs a new exception with the given message.
-	 * 
+	 *
 	 * @param detail the message
 	 */
 	public AssertionFailedException(String detail) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/CoreException.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/CoreException.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -26,7 +26,7 @@ import org.eclipse.core.internal.runtime.PrintStackUtil;
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @see IStatus
  */
 public class CoreException extends Exception {
@@ -52,7 +52,7 @@ public class CoreException extends Exception {
 
 	/**
 	 * Returns the cause of this exception, or <code>null</code> if none.
-	 * 
+	 *
 	 * @return the cause for this exception
 	 * @since 3.4
 	 */
@@ -71,13 +71,13 @@ public class CoreException extends Exception {
 	 * <code>CoreException</code>, and use that new status for error reporting or as
 	 * a method return value. For example, instead of:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * yourPlugin.getLog().log(exception.getStatus());
 	 * </pre>
-	 * 
+	 *
 	 * Use:
-	 * 
+	 *
 	 * <pre>
 	 * IStatus result = new Status(exception.getStatus().getSeverity(), pluginId, message, exception);
 	 * yourPlugin.getLog().log(result);
@@ -101,7 +101,7 @@ public class CoreException extends Exception {
 	/**
 	 * Prints a stack trace out for the exception, and any nested exception that it
 	 * may have embedded in its Status object.
-	 * 
+	 *
 	 * @param output the stream to write to
 	 */
 	@Override
@@ -115,7 +115,7 @@ public class CoreException extends Exception {
 	/**
 	 * Prints a stack trace out for the exception, and any nested exception that it
 	 * may have embedded in its Status object.
-	 * 
+	 *
 	 * @param output the stream to write to
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/FileLocator.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/FileLocator.java
@@ -1,13 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2022 IBM Corporation and others.
  *
- * This program and the accompanying materials 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -28,7 +28,7 @@ import org.osgi.framework.Bundle;
 /**
  * This class contains a collection of helper methods for finding files in
  * bundles. This class can only be used if the OSGi plugin is available.
- * 
+ *
  * @since org.eclipse.equinox.common 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
@@ -59,7 +59,7 @@ public final class FileLocator {
 	 * en_CA will return a URL corresponding to the first location about.properties
 	 * is found according to the following order:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     plugin root/nl/en/CA/about.properties
 	 *     fragment1 root/nl/en/CA/about.properties
@@ -78,7 +78,7 @@ public final class FileLocator {
 	 * The current environment variable values can be overridden using the override
 	 * map argument or <code>null</code> can be specified if this is not desired.
 	 * </p>
-	 * 
+	 *
 	 * @param bundle   the bundle in which to search
 	 * @param path     file path relative to plug-in installation location
 	 * @param override map of override substitution arguments to be used for any
@@ -115,7 +115,7 @@ public final class FileLocator {
 	 * en_CA will return a URL corresponding to the first location about.properties
 	 * is found according to the following order:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     plugin root/nl/en/CA/about.properties
 	 *     fragment1 root/nl/en/CA/about.properties
@@ -130,7 +130,7 @@ public final class FileLocator {
 	 *     fragment2 root/about.properties
 	 *     ...
 	 * </pre>
-	 * 
+	 *
 	 * @see FileLocator#find(Bundle, IPath, Map) for the option to override the
 	 *      current environment variables
 	 *
@@ -149,7 +149,7 @@ public final class FileLocator {
 	 * This method is the same as {@link #find(Bundle, IPath, Map)} except multiple
 	 * entries can be returned if more than one entry matches the path in the host
 	 * and any of its fragments.
-	 * 
+	 *
 	 * @param bundle   the bundle in which to search
 	 * @param path     file path relative to plug-in installation location
 	 * @param override map of override substitution arguments to be used for any
@@ -160,7 +160,7 @@ public final class FileLocator {
 	 *                 substitution argument, the default is used.
 	 * @return an array of entries which match the given path. An empty array is
 	 *         returned if no matches are found.
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public static URL[] findEntries(Bundle bundle, IPath path, Map<String, String> override) {
@@ -192,7 +192,7 @@ public final class FileLocator {
 	 * the first location about.properties is found according to the following
 	 * order:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *     plugin root/nl/en/CA/about.properties
 	 *     fragment1 root/nl/en/CA/about.properties
@@ -207,7 +207,7 @@ public final class FileLocator {
 	 *     fragment2 root/about.properties
 	 *     ...
 	 * </pre>
-	 * 
+	 *
 	 * @param url The location of a bundle entry that potentially includes the above
 	 *            environment variables
 	 * @return The URL of the bundle entry matching the input URL, or
@@ -223,12 +223,12 @@ public final class FileLocator {
 	 * This is a convenience method, fully equivalent to
 	 * {@link #findEntries(Bundle, IPath, Map)}, with a value of <code>null</code>
 	 * for the map argument.
-	 * 
+	 *
 	 * @param bundle the bundle in which to search
 	 * @param path   file path relative to plug-in installation location
 	 * @return an array of entries which match the given path. An empty array is
 	 *         returned if no matches are found.
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public static URL[] findEntries(Bundle bundle, IPath path) {
@@ -266,7 +266,7 @@ public final class FileLocator {
 	 * If the protocol for the given URL is not recognized by this converter, the
 	 * original URL is returned as-is.
 	 * </p>
-	 * 
+	 *
 	 * @param url the original URL
 	 * @return the converted file URL or the original URL passed in if it is not
 	 *         recognized by this converter
@@ -289,7 +289,7 @@ public final class FileLocator {
 	 * If the protocol is not recognized by this converter, then the original URL is
 	 * returned as-is.
 	 * </p>
-	 * 
+	 *
 	 * @param url the original URL
 	 * @return the resolved URL or the original if the protocol is unknown to this
 	 *         converter
@@ -305,11 +305,11 @@ public final class FileLocator {
 	 * Returns a file for the contents of the specified bundle. Depending on how the
 	 * bundle is installed the returned file may be a directory or a jar file
 	 * containing the bundle content.
-	 * 
+	 *
 	 * @param bundle the bundle
 	 * @return a file with the contents of the bundle
 	 * @throws IOException if an error occurs during the resolution
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.4
 	 * @deprecated use {@link #getBundleFileLocation(Bundle)} instead
 	 */
@@ -328,7 +328,7 @@ public final class FileLocator {
 	 * determined the returned {@code Optional} is empty, which is for example
 	 * usually the case for {@code CONNECT} bundles.
 	 * </p>
-	 * 
+	 *
 	 * @param bundle the bundle
 	 * @return the optional file to the location of the bundle's root
 	 * @since 3.16

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdaptable.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdaptable.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -23,7 +23,7 @@ package org.eclipse.core.runtime;
  * managed by type by adapter managers.
  * </p>
  * For example,
- * 
+ *
  * <pre>
  *     IAdaptable a = [some adaptable];
  *     IFoo x = Adapters.getAdapter(a, IFoo.class, true);
@@ -37,7 +37,7 @@ package org.eclipse.core.runtime;
  * Clients may implement this interface, or obtain a default implementation of
  * this interface by subclassing <code>PlatformObject</code>.
  * </p>
- * 
+ *
  * @see IAdapterFactory
  * @see IAdapterManager
  * @see PlatformObject

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdapterFactory.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdapterFactory.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @see IAdapterManager
  * @see IAdaptable
  * @see AdapterTypes
@@ -38,7 +38,7 @@ public interface IAdapterFactory {
 	 * Service property to use when registering a factory as OSGi-service to declare
 	 * the adaptable class type, this is a multi-string-property, if more than one
 	 * is given the factory will be register multiple times
-	 * 
+	 *
 	 * @since 3.14
 	 */
 	static final String SERVICE_PROPERTY_ADAPTABLE_CLASS = "adaptableClass"; //$NON-NLS-1$
@@ -47,7 +47,7 @@ public interface IAdapterFactory {
 	 * Optional service property to use when registering a factory as OSGi-service
 	 * to declare the possible adapter types. If the property is given, the service
 	 * is only queried when actually required, this is a multi-string-property.
-	 * 
+	 *
 	 * @since 3.14
 	 */
 	static final String SERVICE_PROPERTY_ADAPTER_NAMES = "adapterNames"; //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdapterManager.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IAdapterManager.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -34,7 +34,7 @@ package org.eclipse.core.runtime;
  * The following code snippet shows how one might register an adapter of type
  * <code>com.example.acme.Sticky</code> on resources in the workspace.
  * </p>
- * 
+ *
  * <pre>
  *  IAdapterFactory pr = new IAdapterFactory() {
  *  	{@literal @}Override
@@ -60,14 +60,14 @@ package org.eclipse.core.runtime;
  *  }
  *  Platform.getAdapterManager().registerAdapters(pr, IResource.class);
  *   </pre>
- * 
+ *
  * <p>
  * This interface can be used without OSGi running.
  * </p>
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @see IAdaptable
  * @see IAdapterFactory
  * @noextend This interface is not intended to be extended by clients.
@@ -78,7 +78,7 @@ public interface IAdapterManager {
 	/**
 	 * This value can be returned to indicate that no applicable adapter factory was
 	 * found.
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public static final int NONE = 0;
@@ -86,14 +86,14 @@ public interface IAdapterManager {
 	/**
 	 * This value can be returned to indicate that an adapter factory was found, but
 	 * has not been loaded.
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public static final int NOT_LOADED = 1;
 
 	/**
 	 * This value can be returned to indicate that an adapter factory is loaded.
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public static final int LOADED = 2;
@@ -110,7 +110,7 @@ public interface IAdapterManager {
 	 * factory itself returns <code>null</code>, then <code>getAdapter</code> will
 	 * still return <code>null</code>.
 	 * </p>
-	 * 
+	 *
 	 * @param adaptableClass the adaptable class being queried
 	 * @return an array of type names that can be obtained by converting
 	 *         <code>adaptableClass</code> via this manager. An empty array is
@@ -131,7 +131,7 @@ public interface IAdapterManager {
 	 * returned by <code>getInterfaces</code> (in the example, X's superinterfaces
 	 * then Y's superinterfaces)</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param clazz the class for which to return the class order.
 	 * @return the class search order for the given class. The returned search order
 	 *         will minimally contain the target class.
@@ -151,7 +151,7 @@ public interface IAdapterManager {
 	 * {@link Adapters#adapt(Object, Class, boolean)} rather than calling this
 	 * method directly since doing so will also detect interfaces supplied by the
 	 * {@link IAdaptable} interface
-	 * 
+	 *
 	 * @param adaptable   the adaptable object being queried (usually an instance of
 	 *                    <code>IAdaptable</code>)
 	 * @param adapterType the type of adapter to look up
@@ -175,7 +175,7 @@ public interface IAdapterManager {
 	 * {@link Adapters#adapt(Object, Class, boolean)} rather than calling this
 	 * method directly since doing so will also detect interfaces supplied by the
 	 * {@link IAdaptable} interface
-	 * 
+	 *
 	 * @param adaptable       the adaptable object being queried (usually an
 	 *                        instance of <code>IAdaptable</code>)
 	 * @param adapterTypeName the fully qualified name of the type of adapter to
@@ -197,7 +197,7 @@ public interface IAdapterManager {
 	 * return a non-null result. If the factory's plug-in has not yet been loaded,
 	 * or if the factory itself returns <code>null</code>, then
 	 * <code>getAdapter</code> will still return <code>null</code>.
-	 * 
+	 *
 	 * @param adaptable       the adaptable object being queried (usually an
 	 *                        instance of <code>IAdaptable</code>)
 	 * @param adapterTypeName the fully qualified class name of an adapter to look
@@ -223,7 +223,7 @@ public interface IAdapterManager {
 	 * <li>{@link org.eclipse.core.runtime.IAdapterManager#LOADED} if an adapter
 	 * factory was found, and it is loaded.</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param adaptable       the adaptable object being queried (usually an
 	 *                        instance of <code>IAdaptable</code>)
 	 * @param adapterTypeName the fully qualified class name of an adapter to look
@@ -247,7 +247,7 @@ public interface IAdapterManager {
 	 * {@link Adapters#adapt(Object, Class, boolean)} rather than calling this
 	 * method directly since doing so will also detect interfaces supplied by the
 	 * {@link IAdaptable} interface.
-	 * 
+	 *
 	 * @param adaptable       the adaptable object being queried (usually an
 	 *                        instance of <code>IAdaptable</code>)
 	 * @param adapterTypeName the fully qualified name of the type of adapter to
@@ -267,7 +267,7 @@ public interface IAdapterManager {
 	 * interface, the adapters are available to all classes that directly or
 	 * indirectly implement that interface.
 	 * </p>
-	 * 
+	 *
 	 * @param factory   the adapter factory
 	 * @param adaptable the type being extended
 	 * @see #unregisterAdapters(IAdapterFactory)
@@ -281,7 +281,7 @@ public interface IAdapterManager {
 	 * <code>unregisterAdapters(IAdapterFactory,Class)</code> on all classes against
 	 * which it had been explicitly registered. Does nothing if the given factory is
 	 * not currently registered.
-	 * 
+	 *
 	 * @param factory the adapter factory to remove
 	 * @see #registerAdapters(IAdapterFactory, Class)
 	 */
@@ -291,7 +291,7 @@ public interface IAdapterManager {
 	 * Removes the given adapter factory from the list of factories registered as
 	 * extending the given class. Does nothing if the given factory and type
 	 * combination is not registered.
-	 * 
+	 *
 	 * @param factory   the adapter factory to remove
 	 * @param adaptable one of the types against which the given factory is
 	 *                  registered

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IBundleGroup.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IBundleGroup.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -32,7 +32,7 @@ import org.osgi.framework.Bundle;
  * property keys that it will use, for example, to display About information.
  * See <code>org.eclipse.ui.branding.IBundleGroupConstants</code>.
  * </p>
- * 
+ *
  * @see IBundleGroupProvider
  * @since 3.0
  */
@@ -41,7 +41,7 @@ public interface IBundleGroup {
 	/**
 	 * Returns the identifier of this bundle group. Bundle groups are uniquely
 	 * identified by the combination of their identifier and their version.
-	 * 
+	 *
 	 * @see #getVersion()
 	 * @return the identifier for this bundle group
 	 */
@@ -49,7 +49,7 @@ public interface IBundleGroup {
 
 	/**
 	 * Returns the human-readable name of this bundle group.
-	 * 
+	 *
 	 * @return the human-readable name
 	 */
 	public String getName();
@@ -59,7 +59,7 @@ public interface IBundleGroup {
 	 * the same format as bundle versions (i.e., major.minor.service.qualifier).
 	 * Bundle groups are uniquely identified by the combination of their identifier
 	 * and their version.
-	 * 
+	 *
 	 * @see #getIdentifier()
 	 * @return the string form of this bundle group's version
 	 */
@@ -67,21 +67,21 @@ public interface IBundleGroup {
 
 	/**
 	 * Returns a text description of this bundle group.
-	 * 
+	 *
 	 * @return text description of this bundle group
 	 */
 	public String getDescription();
 
 	/**
 	 * Returns the name of the provider of this bundle group.
-	 * 
+	 *
 	 * @return the name of the provider or <code>null</code> if none
 	 */
 	public String getProviderName();
 
 	/**
 	 * Returns a list of all bundles supplied by this bundle group.
-	 * 
+	 *
 	 * @return the bundles supplied by this bundle group
 	 */
 	public Bundle[] getBundles();
@@ -89,7 +89,7 @@ public interface IBundleGroup {
 	/**
 	 * Returns the property of this bundle group with the given key.
 	 * <code>null</code> is returned if there is no such key/value pair.
-	 * 
+	 *
 	 * @param key the name of the property to return
 	 * @return the value associated with the given key or <code>null</code> if none
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IBundleGroupProvider.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IBundleGroupProvider.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -18,7 +18,7 @@ package org.eclipse.core.runtime;
  * the current system. Typically, a configuration agent (i.e., plug-in
  * installer) will define a bundle group provider so that it can report to the
  * system the list of plug-ins it has installed.
- * 
+ *
  * @see IBundleGroup
  * @since 3.0
  */
@@ -26,14 +26,14 @@ public interface IBundleGroupProvider {
 
 	/**
 	 * Returns the human-readable name of this bundle group provider.
-	 * 
+	 *
 	 * @return the name of this bundle group provider
 	 */
 	public String getName();
 
 	/**
 	 * Returns the bundle groups provided by this provider.
-	 * 
+	 *
 	 * @return the bundle groups provided by this provider
 	 */
 	public IBundleGroup[] getBundleGroups();

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ILogListener.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ILogListener.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -28,7 +28,7 @@ public interface ILogListener extends EventListener {
 	/**
 	 * Notifies this listener that given status has been logged by a plug-in. The
 	 * listener is free to retain or ignore this status.
-	 * 
+	 *
 	 * @param status the status being logged
 	 * @param plugin the plugin of the log which generated this event
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IPath.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Patrick Tasse - Add extra constructor to Path class (bug 454959)
@@ -38,7 +38,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface is not intended to be implemented by clients.
  * </p>
- * 
+ *
  * @see Path
  * @noextend This interface is not intended to be extended by clients.
  * @noimplement This interface is not intended to be implemented by clients.
@@ -58,7 +58,7 @@ public interface IPath extends Cloneable {
 	/**
 	 * Constant value containing the empty path with no device on the local file
 	 * system.
-	 * 
+	 *
 	 * @since 3.18
 	 */
 	public static final IPath EMPTY = Path.Constants.empty();
@@ -66,7 +66,7 @@ public interface IPath extends Cloneable {
 	/**
 	 * Constant value containing the root path with no device on the local file
 	 * system.
-	 * 
+	 *
 	 * @since 3.18
 	 */
 	public static final IPath ROOT = Path.Constants.root();
@@ -193,7 +193,7 @@ public interface IPath extends Cloneable {
 	 * separator. The device id of this path is preserved (the one of the given
 	 * string is ignored). Duplicate slashes are removed from the path except at the
 	 * beginning where the path is considered to be UNC.
-	 * 
+	 *
 	 * @param path the string path to concatenate
 	 * @return the new path
 	 * @see #isValidPath(String)
@@ -301,7 +301,7 @@ public interface IPath extends Cloneable {
 	 * An empty path is a prefix of all paths with the same device; a root path is a
 	 * prefix of all absolute paths with the same device.
 	 * </p>
-	 * 
+	 *
 	 * @param anotherPath the other path
 	 * @return <code>true</code> if this path is a prefix of the given path, and
 	 *         <code>false</code> otherwise
@@ -325,7 +325,7 @@ public interface IPath extends Cloneable {
 	 * Returns a boolean value indicating whether or not this path is considered to
 	 * be in UNC form. Return false if this path has a device set or if the first 2
 	 * characters of the path string are not <code>Path.SEPARATOR</code>.
-	 * 
+	 *
 	 * @return boolean indicating if this path is UNC
 	 */
 	public boolean isUNC();
@@ -400,7 +400,7 @@ public interface IPath extends Cloneable {
 	 * is successfully made relative, then appending the returned path to the base
 	 * will always produce a path equal to this path.
 	 * </p>
-	 * 
+	 *
 	 * @param base The base path to make this path relative to
 	 * @return A path relative to the base path, or this path if it could not be
 	 *         made relative to the given base
@@ -415,7 +415,7 @@ public interface IPath extends Cloneable {
 	 * first 2 characters of the path string will be <code>Path.SEPARATOR</code>. If
 	 * not UNC, the first 2 characters of the returned path string will not be
 	 * <code>Path.SEPARATOR</code>.
-	 * 
+	 *
 	 * @param toUNC true if converting to UNC, false otherwise
 	 * @return the new path, either in UNC form or not depending on the boolean
 	 *         parameter
@@ -591,7 +591,7 @@ public interface IPath extends Cloneable {
 	 * <p>
 	 * Example result strings (without and with device id):
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * "/foo/bar.txt"
 	 * "bar.txt"
@@ -606,7 +606,7 @@ public interface IPath extends Cloneable {
 	 * "C:"
 	 * "C:/"
 	 * </pre>
-	 * 
+	 *
 	 * This string is suitable for passing to <code>Path(String)</code>.
 	 *
 	 * @return a string representation of this path

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IProgressMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IProgressMonitor.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Laeubrich 	- [Bug 565924] join with IProgressMonitorWithBlocking, add null aware helper methods
@@ -76,7 +76,7 @@ package org.eclipse.core.runtime;
  * <li>Will pass in a monitor that ignores the name argument to
  * {@link #beginTask} unless the JavaDoc for the callee states otherwise.
  * </ul>
- * 
+ *
  * <p>
  * The responsibilities described above were introduced in Eclipse 4.7 (Oxygen).
  * Prior to Eclipse 4.7, it was common practice for the callee to invoke
@@ -108,7 +108,7 @@ public interface IProgressMonitor {
 	/**
 	 * Notifies that the main task is beginning. This must only be called once on a
 	 * given progress monitor instance.
-	 * 
+	 *
 	 * @param name      the name (or description) of the main task
 	 * @param totalWork the total number of work units into which the main task is
 	 *                  been subdivided. If the value is <code>UNKNOWN</code> the
@@ -127,7 +127,7 @@ public interface IProgressMonitor {
 	/**
 	 * Internal method to handle scaling correctly. This method must not be called
 	 * by a client. Clients should always use the method <code>worked(int)</code>.
-	 * 
+	 *
 	 * @param work the amount of work done
 	 */
 	public void internalWorked(double work);
@@ -144,7 +144,7 @@ public interface IProgressMonitor {
 
 	/**
 	 * Sets the cancel state to the given value.
-	 * 
+	 *
 	 * @param value <code>true</code> indicates that cancelation has been requested
 	 *              (but not necessarily acknowledged); <code>false</code> clears
 	 *              this flag
@@ -189,7 +189,7 @@ public interface IProgressMonitor {
 	 * blocking the caller. If this blocking job is not known, this method will
 	 * return a plain informational <code>IStatus</code> object.
 	 * </p>
-	 * 
+	 *
 	 * @param reason an optional status object whose message describes the reason
 	 *               why this operation is blocked, or <code>null</code> if this
 	 *               information is not available.
@@ -204,7 +204,7 @@ public interface IProgressMonitor {
 	 * Clears the blocked state of the running operation. If a running operation
 	 * ever calls <code>setBlocked</code>, it must eventually call
 	 * <code>clearBlocked</code> before the operation completes.
-	 * 
+	 *
 	 * @see #setBlocked(IStatus)
 	 * @since 3.13
 	 */
@@ -220,10 +220,10 @@ public interface IProgressMonitor {
 	 * therefore only be used by one thread at once. To account for this, if sliced
 	 * instances are passed to another thread, only sliced instances should be used
 	 * like in this example:
-	 * 
+	 *
 	 * <pre>
 	 * IProgressMonitor monitor = ...
-	 * 
+	 *
 	 * processAsync(monitor.slice(70));
 	 * monitor = monitor.slice(30); // get a local slice so we can use the monitor
 	 * 								// without interference with the async processing
@@ -231,16 +231,16 @@ public interface IProgressMonitor {
 	 * ...
 	 * monitor.worked(1);           // this is now safe to be called further on
 	 * ...
-	 * monitor.done();				// mark our part as done, 
+	 * monitor.done();				// mark our part as done,
 	 * 								// the other slice will be finished by processAsync(...)
 	 * 								// ... and the original monitor by the caller of this method
-	 * 
+	 *
 	 * </pre>
-	 * 
+	 *
 	 * The caller of this method (or the Thread that gets this instance passed) is
 	 * responsible to make sure that {@link #done()} is called once the monitor is
 	 * no longer needed.
-	 * 
+	 *
 	 * @param work the amount of work for this {@link IProgressMonitor} to slice
 	 * @return a {@link IProgressMonitor} slice for the given amount, the default
 	 *         implementation suppress any strings passed to
@@ -256,7 +256,7 @@ public interface IProgressMonitor {
 	/**
 	 * Calls {@link #done()} on the given monitor if is non-null. If the given
 	 * monitor is null, this is a no-op.
-	 * 
+	 *
 	 * @param monitor the monitor to make done, might be <code>null</code>
 	 * @since 3.14
 	 */
@@ -270,7 +270,7 @@ public interface IProgressMonitor {
 	 * Returns a <code>null</code> safe access to the given monitor, for example in
 	 * cases where a monitor is passed to a function the implementation can call
 	 * this method to get a guaranteed non-null monitor reference
-	 * 
+	 *
 	 * @param monitor the monitor to check
 	 * @return the passed monitor instance or {@link NullProgressMonitor} if monitor
 	 *         was <code>null</code>

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IProgressMonitorWithBlocking.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IProgressMonitorWithBlocking.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM - Initial API and implementation
  *     Christoph Laeubrich - join with IProgressMonitorWithBlocking
@@ -31,7 +31,7 @@ package org.eclipse.core.runtime;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @see IProgressMonitor
  * @since 3.0
  */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ISafeRunnable.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ISafeRunnable.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,7 @@ package org.eclipse.core.runtime;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @see SafeRunner#run(ISafeRunnable)
  */
 @FunctionalInterface

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ISafeRunnableWithResult.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ISafeRunnableWithResult.java
@@ -25,10 +25,10 @@ package org.eclipse.core.runtime;
  * <p>
  * Clients may implement this interface.
  * </p>
- * 
+ *
  * @param <T> the type of the result
  * @see SafeRunner#run(ISafeRunnableWithResult)
- * 
+ *
  * @since 3.11
  */
 @FunctionalInterface
@@ -42,7 +42,7 @@ public interface ISafeRunnableWithResult<T> extends ISafeRunnable {
 	 * Runs this runnable and returns the result. Any exceptions thrown from this
 	 * method will be logged by the caller and passed to this runnable's
 	 * {@link #handleException} method.
-	 * 
+	 *
 	 * @return the result
 	 *
 	 * @exception Exception if a problem occurred while running this method

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IStatus.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/IStatus.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -41,7 +41,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This interface can be used without OSGi running.
  * </p>
- * 
+ *
  * @see MultiStatus
  * @see Status
  */
@@ -51,7 +51,7 @@ public interface IStatus {
 	 * Status severity constant (value 0) indicating this status represents the
 	 * nominal case. This constant is also used as the status code representing the
 	 * nominal case.
-	 * 
+	 *
 	 * @see #getSeverity()
 	 * @see #isOK()
 	 * @see Status#OK_STATUS
@@ -61,7 +61,7 @@ public interface IStatus {
 	/**
 	 * Status type severity (bit mask, value 1) indicating this status is
 	 * informational only.
-	 * 
+	 *
 	 * @see #getSeverity()
 	 * @see #matches(int)
 	 * @see Status#info(String)
@@ -71,7 +71,7 @@ public interface IStatus {
 	/**
 	 * Status type severity (bit mask, value 2) indicating this status represents a
 	 * warning.
-	 * 
+	 *
 	 * @see #getSeverity()
 	 * @see #matches(int)
 	 * @see Status#warning(String)
@@ -82,7 +82,7 @@ public interface IStatus {
 	/**
 	 * Status type severity (bit mask, value 4) indicating this status represents an
 	 * error.
-	 * 
+	 *
 	 * @see #getSeverity()
 	 * @see #matches(int)
 	 * @see Status#error(String)
@@ -93,7 +93,7 @@ public interface IStatus {
 	/**
 	 * Status type severity (bit mask, value 8) indicating this status represents a
 	 * cancelation
-	 * 
+	 *
 	 * @see #getSeverity()
 	 * @see #matches(int)
 	 * @see Status#CANCEL_STATUS

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ListenerList.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ListenerList.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Mikael Barbero (Eclipse Foundation) - Bug 509234
@@ -37,7 +37,7 @@ import java.util.stream.StreamSupport;
  * for notifying all registered listeners of say,
  * <code>FooListener#eventHappened(Event)</code>, is:
  * </p>
- * 
+ *
  * <pre>
  * ListenerList&lt;FooListener&gt; fooListeners = new ListenerList&lt;&gt;();
  * //...
@@ -53,7 +53,7 @@ import java.util.stream.StreamSupport;
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @param <E> the type of listeners in this list
  * @since org.eclipse.equinox.common 3.2
  */
@@ -98,7 +98,7 @@ public class ListenerList<E> implements Iterable<E> {
 
 	/**
 	 * Creates a listener list using the provided comparison mode.
-	 * 
+	 *
 	 * @param mode The mode used to determine if listeners are the
 	 *             <a href="ListenerList.html#same">same</a>.
 	 */
@@ -112,7 +112,7 @@ public class ListenerList<E> implements Iterable<E> {
 	/**
 	 * Adds a listener to this list. This method has no effect if the
 	 * <a href="ListenerList.html#same">same</a> listener is already registered.
-	 * 
+	 *
 	 * @param listener the non-<code>null</code> listener to add
 	 */
 	public synchronized void add(E listener) {
@@ -163,7 +163,7 @@ public class ListenerList<E> implements Iterable<E> {
 	 * is unaffected by subsequent adds or removes. Use this method when notifying
 	 * listeners, so that any modifications to the listener list during the
 	 * notification will have no effect on the notification itself.
-	 * 
+	 *
 	 * @return an iterator
 	 * @since org.eclipse.equinox.common 3.8
 	 */
@@ -264,7 +264,7 @@ public class ListenerList<E> implements Iterable<E> {
 	 * <p>
 	 * The spliterator reports Spliterator.SIZED, Spliterator.SUBSIZED,
 	 * Spliterator.ORDERED, and Spliterator.IMMUTABLE
-	 * 
+	 *
 	 * @return a spliterator for listeners
 	 * @since org.eclipse.equinox.common 3.9
 	 */
@@ -276,7 +276,7 @@ public class ListenerList<E> implements Iterable<E> {
 
 	/**
 	 * Returns a sequential {@code Stream} over the registered listeners.
-	 * 
+	 *
 	 * @return a sequential {@code Stream} over the registered listeners.
 	 * @since org.eclipse.equinox.common 3.9
 	 */
@@ -286,7 +286,7 @@ public class ListenerList<E> implements Iterable<E> {
 
 	/**
 	 * Returns a parallel {@code Stream} over the registered listeners.
-	 * 
+	 *
 	 * @return a parallel {@code Stream} over the registered listeners.
 	 * @since org.eclipse.equinox.common 3.9
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/MultiStatus.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/MultiStatus.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - Bug 561712
@@ -39,7 +39,7 @@ public class MultiStatus extends Status {
 	 * @param message     a human-readable message, localized to the current locale
 	 * @param exception   a low-level exception, or <code>null</code> if not
 	 *                    applicable
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public MultiStatus(Class<?> caller, int code, IStatus[] newChildren, String message, Throwable exception) {
@@ -72,7 +72,7 @@ public class MultiStatus extends Status {
 	 * @param message   a human-readable message, localized to the current locale
 	 * @param exception a low-level exception, or <code>null</code> if not
 	 *                  applicable
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public MultiStatus(Class<?> caller, int code, String message, Throwable exception) {
@@ -98,7 +98,7 @@ public class MultiStatus extends Status {
 	 * @param caller  the relevant class to build unique identifier from
 	 * @param code    the caller-specific status code
 	 * @param message a human-readable message, localized to the current locale
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public MultiStatus(Class<?> caller, int code, String message) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/NullProgressMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/NullProgressMonitor.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -40,7 +40,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 	/**
 	 * This implementation does nothing. Subclasses may override this method to do
 	 * interesting processing when a task begins.
-	 * 
+	 *
 	 * @see IProgressMonitor#beginTask(String, int)
 	 */
 	@Override
@@ -51,7 +51,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 	/**
 	 * This implementation does nothing. Subclasses may override this method to do
 	 * interesting processing when a task is done.
-	 * 
+	 *
 	 * @see IProgressMonitor#done()
 	 */
 	@Override
@@ -61,7 +61,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 
 	/**
 	 * This implementation does nothing. Subclasses may override this method.
-	 * 
+	 *
 	 * @see IProgressMonitor#internalWorked(double)
 	 */
 	@Override
@@ -97,7 +97,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 	/**
 	 * This implementation does nothing. Subclasses may override this method to do
 	 * something with the name of the task.
-	 * 
+	 *
 	 * @see IProgressMonitor#setTaskName(String)
 	 */
 	@Override
@@ -108,7 +108,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 	/**
 	 * This implementation does nothing. Subclasses may override this method to do
 	 * interesting processing when a subtask begins.
-	 * 
+	 *
 	 * @see IProgressMonitor#subTask(String)
 	 */
 	@Override
@@ -119,7 +119,7 @@ public class NullProgressMonitor implements IProgressMonitor {
 	/**
 	 * This implementation does nothing. Subclasses may override this method to do
 	 * interesting processing when some work has been completed.
-	 * 
+	 *
 	 * @see IProgressMonitor#worked(int)
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/OperationCanceledException.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/OperationCanceledException.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -39,7 +39,7 @@ public final class OperationCanceledException extends RuntimeException {
 
 	/**
 	 * Creates a new exception with the given message.
-	 * 
+	 *
 	 * @param message the message for the exception
 	 */
 	public OperationCanceledException(String message) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Path.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Patrick Tasse - Add extra constructor to Path class (bug 454959)
@@ -21,13 +21,13 @@ import java.util.Arrays;
  * The standard implementation of the <code>IPath</code> interface. Paths are
  * always maintained in canonicalized form. That is, parent references (i.e.,
  * <code>../../</code>) and duplicate separators are resolved. For example,
- * 
+ *
  * <pre>
  * new Path("/a/b").append("../foo/bar")
  * </pre>
- * 
+ *
  * will yield the path
- * 
+ *
  * <pre>
  *      /a/foo/bar
  * </pre>
@@ -38,7 +38,7 @@ import java.util.Arrays;
  * This class is not intended to be subclassed by clients but may be
  * instantiated.
  * </p>
- * 
+ *
  * @see IPath
  * @noextend This class is not intended to be subclassed by clients.
  */
@@ -69,7 +69,7 @@ public final class Path implements IPath, Cloneable {
 		/**
 		 * We have cycle : Path implements IPath and IPath uses Path object instances in
 		 * interface constants.
-		 * 
+		 *
 		 * Constants and methods below are needed to resolve init order issues between
 		 * IPath and Path classes - depending on which is loaded first, constants
 		 * defined in one of the classes and pointing to other one will see not
@@ -100,7 +100,7 @@ public final class Path implements IPath, Cloneable {
 	 * Instead of referencing this constants it is recommended to use
 	 * {@link IPath#EMPTY} instead.
 	 * </p>
-	 * 
+	 *
 	 * @see IPath#EMPTY
 	 */
 	public static final Path EMPTY = Constants.empty();
@@ -112,7 +112,7 @@ public final class Path implements IPath, Cloneable {
 	 * Instead of referencing this constants it is recommended to use
 	 * {@link IPath#ROOT} instead.
 	 * </p>
-	 * 
+	 *
 	 * @see IPath#ROOT
 	 */
 	public static final Path ROOT = Constants.root();
@@ -215,7 +215,7 @@ public final class Path implements IPath, Cloneable {
 	 * Instead of calling this method it is recommended to call
 	 * {@link IPath#forPosix(String)} instead.
 	 * </p>
-	 * 
+	 *
 	 * @param fullPath the string path
 	 * @return the IPath representing the given POSIX string path
 	 * @see #isValidPosixPath(String)
@@ -238,7 +238,7 @@ public final class Path implements IPath, Cloneable {
 	 * Instead of calling this method it is recommended to call
 	 * {@link IPath#forWindows(String)} instead.
 	 * </p>
-	 * 
+	 *
 	 * @param fullPath the string path
 	 * @return the IPath representing the given Windows string path
 	 * @see #isValidWindowsPath(String)
@@ -360,7 +360,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#addFileExtension
 	 */
 	@Override
@@ -377,7 +377,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#addTrailingSeparator
 	 */
 	@Override
@@ -395,7 +395,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#append(IPath)
 	 */
 	@Override
@@ -432,7 +432,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#append(java.lang.String)
 	 */
 	@Override
@@ -466,7 +466,7 @@ public final class Path implements IPath, Cloneable {
 	 * In its canonical form, a path does not have any "." segments, and parent
 	 * references ("..") are collapsed where possible.
 	 * </p>
-	 * 
+	 *
 	 * @return true if the path was modified, and false otherwise.
 	 */
 	private static String[] canonicalize(boolean isAbsolute, String[] segments) {
@@ -732,7 +732,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#getDevice
 	 */
 	@Override
@@ -742,7 +742,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#getFileExtension
 	 */
 	@Override
@@ -776,7 +776,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#hasTrailingSeparator2
 	 */
 	@Override
@@ -834,7 +834,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isAbsolute
 	 */
 	@Override
@@ -845,7 +845,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isEmpty
 	 */
 	@Override
@@ -856,7 +856,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isPrefixOf
 	 */
 	@Override
@@ -888,7 +888,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isRoot
 	 */
 	@Override
@@ -899,7 +899,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isUNC
 	 */
 	@Override
@@ -912,7 +912,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isValidPath(String)
 	 */
 	@Override
@@ -982,7 +982,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#isValidSegment(String)
 	 */
 	@Override
@@ -1062,7 +1062,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#lastSegment()
 	 */
 	@Override
@@ -1074,7 +1074,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#makeAbsolute()
 	 */
 	@Override
@@ -1095,7 +1095,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#makeRelative()
 	 */
 	@Override
@@ -1108,7 +1108,7 @@ public final class Path implements IPath, Cloneable {
 
 	/**
 	 * {@inheritDoc}
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.5
 	 */
 	@Override
@@ -1133,7 +1133,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#makeUNC(boolean)
 	 */
 	@Override
@@ -1155,7 +1155,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#matchingFirstSegments(IPath)
 	 */
 	@Override
@@ -1176,7 +1176,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#removeFileExtension()
 	 */
 	@Override
@@ -1192,7 +1192,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#removeFirstSegments(int)
 	 */
 	@Override
@@ -1214,7 +1214,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#removeLastSegments(int)
 	 */
 	@Override
@@ -1235,7 +1235,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#removeTrailingSeparator()
 	 */
 	@Override
@@ -1248,7 +1248,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#segment(int)
 	 */
 	@Override
@@ -1266,7 +1266,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#segmentCount()
 	 */
 	@Override
@@ -1276,7 +1276,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#segments()
 	 */
 	@Override
@@ -1287,7 +1287,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#setDevice(String)
 	 */
 	@Override
@@ -1306,7 +1306,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#toFile()
 	 */
 	@Override
@@ -1316,7 +1316,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#toOSString()
 	 */
 	@Override
@@ -1364,7 +1364,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#toPortableString()
 	 */
 	@Override
@@ -1401,7 +1401,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#toString()
 	 */
 	@Override
@@ -1446,7 +1446,7 @@ public final class Path implements IPath, Cloneable {
 
 	/*
 	 * (Intentionally not included in javadoc)
-	 * 
+	 *
 	 * @see IPath#uptoSegment(int)
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PlatformObject.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PlatformObject.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -27,10 +27,10 @@ import org.eclipse.core.internal.runtime.AdapterManager;
  * implementation of the {@link IAdapterManager} service. The method would look
  * like:
  * </p>
- * 
+ *
  * <pre>
  *     public &lt;T&gt; T getAdapter(Class&lt;T&gt; adapter) {
- *         IAdapterManager manager = ...;//lookup the IAdapterManager service         
+ *         IAdapterManager manager = ...;//lookup the IAdapterManager service
  *         return manager.getAdapter(this, adapter);
  *     }
  * </pre>

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PluginVersionIdentifier.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/PluginVersionIdentifier.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Sergey Prigogin (Google) - use parameterized types (bug 442021)
@@ -56,7 +56,7 @@ import org.osgi.framework.Version;
  * <p>
  * Clients may instantiate; not intended to be subclassed by clients.
  * </p>
- * 
+ *
  * @see java.lang.String#compareTo(java.lang.String)
  * @deprecated clients should use {@link org.osgi.framework.Version} instead
  */
@@ -69,7 +69,7 @@ public final class PluginVersionIdentifier {
 
 	/**
 	 * Creates a plug-in version identifier from its components.
-	 * 
+	 *
 	 * @param major   major component of the version identifier
 	 * @param minor   minor component of the version identifier
 	 * @param service service update component of the version identifier
@@ -80,7 +80,7 @@ public final class PluginVersionIdentifier {
 
 	/**
 	 * Creates a plug-in version identifier from its components.
-	 * 
+	 *
 	 * @param major     major component of the version identifier
 	 * @param minor     minor component of the version identifier
 	 * @param service   service update component of the version identifier
@@ -119,7 +119,7 @@ public final class PluginVersionIdentifier {
 	 * <li><code>1.9</code> (interpreted as <code>1.9.0</code>)</li>
 	 * <li><code>3</code> (interpreted as <code>3.0.0</code>)</li>
 	 * </ul>
-	 * 
+	 *
 	 * @param versionId string representation of the version identifier. Qualifier
 	 *                  characters that are not a letter or a digit are replaced.
 	 */
@@ -131,7 +131,7 @@ public final class PluginVersionIdentifier {
 
 	/**
 	 * Validates the given string as a plug-in version identifier.
-	 * 
+	 *
 	 * @param version the string to validate
 	 * @return a status object with code <code>IStatus.OK</code> if the given string
 	 *         is valid as a plug-in version identifier, otherwise a status object
@@ -386,7 +386,7 @@ public final class PluginVersionIdentifier {
 	 * argument. If the service levels are equal, the two version identifiers are
 	 * considered to be equivalent if this qualifier is greater or equal to the
 	 * qualifier of the argument (using lexicographic string comparison).
-	 * 
+	 *
 	 * </p>
 	 *
 	 * @param id the other version identifier

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ProgressMonitorWrapper.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ProgressMonitorWrapper.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Christoph Laeubrich - adjust to new API

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/QualifiedName.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/QualifiedName.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -42,7 +42,7 @@ public final class QualifiedName {
 	 * <p>
 	 * Clients may instantiate.
 	 * </p>
-	 * 
+	 *
 	 * @param qualifier the qualifier string, or <code>null</code>
 	 * @param localName the local name string
 	 */
@@ -104,7 +104,7 @@ public final class QualifiedName {
 	/*
 	 * (Intentionally omitted from javadoc) Implements the method
 	 * <code>Object.hashCode</code>.
-	 * 
+	 *
 	 * Returns the hash code for this qualified name.
 	 */
 	@Override

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SafeRunner.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SafeRunner.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -23,7 +23,7 @@ import org.eclipse.osgi.util.NLS;
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.common 3.2
  */
 public final class SafeRunner {
@@ -61,7 +61,7 @@ public final class SafeRunner {
 	 * the code being executed. Severe errors that are not generally safe to catch
 	 * are not caught by this method.
 	 * </p>
-	 * 
+	 *
 	 * @param <T>  the result type
 	 *
 	 * @param code the runnable to run

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ServiceCaller.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/ServiceCaller.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Alex Blewitt - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - documentation improvements
@@ -53,7 +53,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * <p>
  * Single invocation example:
  * </p>
- * 
+ *
  * <pre>
  * ServiceCaller.callOnce(MyClass.class, ILog.class, (logger) -&gt; logger.info("All systems go!"));
  * </pre>
@@ -68,7 +68,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * This allows boilerplate code to be reduced at call sites, which would
  * otherwise have to do something like:
  * </p>
- * 
+ *
  * <pre>
  * Bundle bundle = FrameworkUtil.getBundle(BadExample.class);
  * BundleContext context = bundle == null ? null : bundle.getBundleContext();
@@ -89,10 +89,10 @@ import org.osgi.util.tracker.ServiceTracker;
  * lazy instantiation of the service instance. For example, if logging is used
  * more often then something like the following could be used:
  * </p>
- * 
+ *
  * <pre>
  * static final ServiceCaller&lt;ILog&gt; log = new ServiceCaller(MyClass.class, ILog.class);
- * 
+ *
  * static void info(String msg) {
  * 	log.call(logger -&gt; logger.info(msg));
  * }
@@ -102,7 +102,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * advanced cases should use other mechanisms such as the {@link ServiceTracker}
  * or declarative services.
  * </p>
- * 
+ *
  * @param <S> the service type for this caller
  * @since 3.13
  */
@@ -120,7 +120,7 @@ public class ServiceCaller<S> {
 	 * the consumer throws a checked exception, it can be propagated using a
 	 * <em>sneakyThrow</em> inside a try/catch block:
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * callOnce(MyClass.class, Callable.class, (callable) -&gt; {
 	 *   try {
@@ -135,7 +135,7 @@ public class ServiceCaller<S> {
 	 *   throw (E) e;
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * @param caller      a class from the bundle that will use service
 	 * @param serviceType the OSGi service type to look up
 	 * @param consumer    the consumer of the OSGi service
@@ -152,7 +152,7 @@ public class ServiceCaller<S> {
 
 	/**
 	 * As {@link #callOnce(Class, Class, Consumer)} with an additional OSGi filter.
-	 * 
+	 *
 	 * @param caller      a class from the bundle that will use service
 	 * @param serviceType the OSGi service type to look up
 	 * @param consumer    the consumer of the OSGi service
@@ -290,7 +290,7 @@ public class ServiceCaller<S> {
 	/**
 	 * Creates a {@code ServiceCaller} instance for invoking an OSGi service many
 	 * times with a consumer function.
-	 * 
+	 *
 	 * @param caller      a class from the bundle that will consume the service
 	 * @param serviceType the OSGi service type to look up
 	 * @throws NullPointerException  if any of the parameters are {@code null}
@@ -304,7 +304,7 @@ public class ServiceCaller<S> {
 	/**
 	 * Creates a {@code ServiceCaller} instance for invoking an OSGi service many
 	 * times with a consumer function.
-	 * 
+	 *
 	 * @param caller      a class from the bundle that will consume the service
 	 * @param serviceType the OSGi service type to look up
 	 * @param filter      the service filter used to look up the service. May be
@@ -350,10 +350,10 @@ public class ServiceCaller<S> {
 	 * <li>The caller bundle is stopped.</li>
 	 * <li>The service rankings have changed.</li>
 	 * </ul>
-	 * 
+	 *
 	 * After one of these conditions occur subsequent calls to this method will try
 	 * to acquire the another service instance.
-	 * 
+	 *
 	 * @param consumer the consumer of the OSGi service
 	 * @return true if the OSGi service was located and called successfully, false
 	 *         otherwise
@@ -367,7 +367,7 @@ public class ServiceCaller<S> {
 
 	/**
 	 * Return the currently available service.
-	 * 
+	 *
 	 * @return the currently available service or empty if the service cannot be
 	 *         found.
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SlicedProgressMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SlicedProgressMonitor.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Christoph Laeubrich - initial API and implementation
  *******************************************************************************/
@@ -16,7 +16,7 @@ package org.eclipse.core.runtime;
 /**
  * default implementation of a {@link SlicedProgressMonitor} that synchronizes
  * on the given monitor to report work
- * 
+ *
  * @since 3.14
  */
 public class SlicedProgressMonitor implements IProgressMonitor {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Status.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/Status.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Alexander Fedorov (ArSysOp) - Bug 561712
@@ -47,7 +47,7 @@ public class Status implements IStatus {
 	public static final IStatus OK_STATUS = new Status(OK, unknownId, OK, LocalizationUtils.safeLocalize("ok"), null); //$NON-NLS-1$
 	/**
 	 * A standard CANCEL status with no message.
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	public static final IStatus CANCEL_STATUS = new Status(CANCEL, unknownId, 1, "", null); //$NON-NLS-1$
@@ -202,7 +202,7 @@ public class Status implements IStatus {
 	 *                  interpolated.
 	 * @param exception a low-level exception, or <code>null</code> if not
 	 *                  applicable
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public Status(int severity, Class<?> caller, int code, String message, Throwable exception) {
@@ -258,7 +258,7 @@ public class Status implements IStatus {
 	 *                  interpolated.
 	 * @param exception a low-level exception, or <code>null</code> if not
 	 *                  applicable
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public Status(int severity, Class<?> caller, String message, Throwable exception) {
@@ -282,7 +282,7 @@ public class Status implements IStatus {
 	 *                  interpolated.
 	 * @param exception a low-level exception, or <code>null</code> if not
 	 *                  applicable
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public Status(int severity, String pluginId, String message, Throwable exception) {
@@ -303,7 +303,7 @@ public class Status implements IStatus {
 	 *                 <code>CANCEL</code>
 	 * @param caller   the relevant class to build unique identifier from
 	 * @param message  a human-readable message, localized to the current locale
-	 * 
+	 *
 	 * @since 3.12
 	 */
 	public Status(int severity, Class<?> caller, String message) {
@@ -324,7 +324,7 @@ public class Status implements IStatus {
 	 *                 <code>CANCEL</code>
 	 * @param pluginId the unique identifier of the relevant plug-in
 	 * @param message  a human-readable message, localized to the current locale
-	 * 
+	 *
 	 * @since org.eclipse.equinox.common 3.3
 	 */
 	public Status(int severity, String pluginId, String message) {
@@ -338,7 +338,7 @@ public class Status implements IStatus {
 	/**
 	 * Extracts an identifier from the given class: either bundle symbolic name or
 	 * class name, never returns <code>null</code>
-	 * 
+	 *
 	 * @param caller the relevant class to build unique identifier from
 	 * @return identifier extracted for the given class
 	 */

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SubMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SubMonitor.java
@@ -7,10 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Stefan Xenos - initial API and implementation
- *     Stefan Xenos - bug 174539 - add a 1-argument convert(...) method     
+ *     Stefan Xenos - bug 174539 - add a 1-argument convert(...) method
  *     Stefan Xenos - bug 174040 - SubMonitor#convert doesn't always set task name
  *     Stefan Xenos - bug 206942 - updated javadoc to recommend better constants for infinite progress
  *     Stefan Xenos (Google) - bug 475747 - Support efficient, convenient cancellation checks in SubMonitor
@@ -47,7 +47,7 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <p>
  * <b>USAGE:</b>
  * </p>
- * 
+ *
  * <p>
  * When implementing a method that accepts an IProgressMonitor:
  * </p>
@@ -57,7 +57,7 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <li>Use <code>SubMonitor.split(...)</code> whenever you need to call another
  * method that accepts an IProgressMonitor.</li>
  * </ul>
- * 
+ *
  * <p>
  * <b>Example: Recommended usage</b>
  * </p>
@@ -67,7 +67,7 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <code>SubMonitor</code> makes it unnecessary to call IProgressMonitor.done()
  * in most situations.
  * </p>
- * 
+ *
  * <p>
  * It is never necessary to call done() on a monitor obtained from
  * <code>convert</code> or <code>progress.split()</code>. In this example, there
@@ -76,27 +76,27 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <code>monitor.done()</code>. The JavaDoc contract makes this the
  * responsibility of the caller.
  * </p>
- * 
+ *
  * <pre>
  *      // {@literal @}param monitor the progress monitor to use for reporting progress to the user. It is the caller's responsibility
  *      //        to call done() on the given monitor. Accepts <code>null</code>, indicating that no progress should be
  *      //        reported and that the operation cannot be cancelled.
  *      //
  *      void doSomething(IProgressMonitor monitor) {
- *          // Convert the given monitor into a progress instance 
+ *          // Convert the given monitor into a progress instance
  *          SubMonitor progress = SubMonitor.convert(monitor, 100);
- *              
+ *
  *          // Use 30% of the progress to do some work
  *          doSomeWork(progress.split(30));
- *          
+ *
  *          // Advance the monitor by another 30%
  *          progress.split(30);
- *          
+ *
  *          // Use the remaining 40% of the progress to do some more work
- *          doSomeWork(progress.split(40)); 
+ *          doSomeWork(progress.split(40));
  *      }
  * </pre>
- * 
+ *
  * <p>
  * <b>Example: Branches</b>
  * </p>
@@ -105,29 +105,29 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * This example demonstrates how to smoothly report progress in situations where
  * some of the work is optional.
  * </p>
- * 
+ *
  * <pre>
  * void doSomething(IProgressMonitor monitor) {
  * 	SubMonitor progress = SubMonitor.convert(monitor, 100);
- * 
+ *
  * 	if (condition) {
  * 		// Use 50% of the progress to do some work
  * 		doSomeWork(progress.split(50));
  * 	}
- * 
+ *
  * 	// Don't report any work, but ensure that we have 50 ticks remaining on the
  * 	// progress monitor.
  * 	// If we already consumed 50 ticks in the above branch, this is a no-op.
  * 	// Otherwise, the remaining
  * 	// space in the monitor is redistributed into 50 ticks.
- * 
+ *
  * 	progress.setWorkRemaining(50);
- * 
+ *
  * 	// Use the remainder of the progress monitor to do the rest of the work
  * 	doSomeWork(progress.split(50));
  * }
  * </pre>
- * 
+ *
  * <p>
  * Please beware of the following anti-pattern:
  * </p>
@@ -143,8 +143,8 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * 	progress.worked(50);
  * }
  * </pre>
- * 
- * 
+ *
+ *
  * <p>
  * <b>Example: Loops</b>
  * </p>
@@ -152,7 +152,7 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <p>
  * This example demonstrates how to report progress in a loop.
  * </p>
- * 
+ *
  * <pre>
  * void doSomething(IProgressMonitor monitor, Collection someCollection) {
  * 	SubMonitor progress = SubMonitor.convert(monitor, 100);
@@ -161,13 +161,13 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * 	// allocate one tick
  * 	// for each element of the given collection.
  * 	SubMonitor loopProgress = progress.split(70).setWorkRemaining(someCollection.size());
- * 
+ *
  * 	for (Iterator iter = someCollection.iterator(); iter.hasNext();) {
  * 		Object next = iter.next();
- * 
+ *
  * 		doWorkOnElement(next, loopProgress.split(1));
  * 	}
- * 
+ *
  * 	// Use the remaining 30% of the progress monitor to do some work outside the
  * 	// loop
  * 	doSomeWork(progress.split(30));
@@ -178,32 +178,32 @@ import org.eclipse.core.internal.runtime.TracingOptions;
  * <p>
  * <b>Example: Infinite progress</b>
  * </p>
- * 
+ *
  * <p>
  * This example demonstrates how to report logarithmic progress in situations
  * where the number of ticks cannot be easily computed in advance.
  * </p>
- * 
+ *
  * <pre>
  * void doSomething(IProgressMonitor monitor, LinkedListNode node) {
  * 	SubMonitor progress = SubMonitor.convert(monitor);
- * 
+ *
  * 	while (node != null) {
  * 		// Regardless of the amount of progress reported so far,
  * 		// use 0.01% of the space remaining in the monitor to process the next node.
  * 		progress.setWorkRemaining(10000);
- * 
+ *
  * 		doWorkOnElement(node, progress.split(1));
- * 
+ *
  * 		node = node.next;
  * 	}
  * }
  * </pre>
- * 
+ *
  * <p>
  * This class can be used without OSGi running.
  * </p>
- * 
+ *
  * @since org.eclipse.equinox.common 3.3
  */
 public final class SubMonitor implements IProgressMonitorWithBlocking {
@@ -404,7 +404,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	/**
 	 * May be passed as a flag to {@link #split}. Indicates that isCanceled should
 	 * always return false.
-	 * 
+	 *
 	 * @since 3.8
 	 */
 	public static final int SUPPRESS_ISCANCELED = 0x0008;
@@ -439,7 +439,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	/**
 	 * Creates a new SubMonitor that will report its progress via the given
 	 * RootInfo.
-	 * 
+	 *
 	 * @param rootInfo            the root of this progress monitor tree
 	 * @param totalWork           total work to perform on the given progress
 	 *                            monitor
@@ -461,19 +461,19 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * not necessary to call done() on the result, but the caller is responsible for
 	 * calling done() on the argument. Calls beginTask on the argument.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method should generally be called at the beginning of a method that
 	 * accepts an IProgressMonitor in order to convert the IProgressMonitor into a
 	 * SubMonitor.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Since it is illegal to call beginTask on the same IProgressMonitor more than
 	 * once, the same instance of IProgressMonitor must not be passed to convert
 	 * more than once.
 	 * </p>
-	 * 
+	 *
 	 * @param monitor monitor to convert to a SubMonitor instance or null. Treats
 	 *                null as a new instance of <code>NullProgressMonitor</code>.
 	 * @return a SubMonitor instance that adapts the argument
@@ -489,7 +489,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * on the result, but the caller is responsible for calling done() on the
 	 * argument. Calls beginTask on the argument.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method should generally be called at the beginning of a method that
 	 * accepts an IProgressMonitor in order to convert the IProgressMonitor into a
@@ -501,7 +501,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * once, the same instance of IProgressMonitor must not be passed to convert
 	 * more than once.
 	 * </p>
-	 * 
+	 *
 	 * @param monitor monitor to convert to a SubMonitor instance or null. Treats
 	 *                null as a new instance of <code>NullProgressMonitor</code>.
 	 * @param work    number of ticks that will be available in the resulting
@@ -519,7 +519,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * on the result, but the caller is responsible for calling done() on the
 	 * argument. Calls beginTask on the argument.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method should generally be called at the beginning of a method that
 	 * accepts an IProgressMonitor in order to convert the IProgressMonitor into a
@@ -531,7 +531,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * once, the same instance of IProgressMonitor must not be passed to convert
 	 * more than once.
 	 * </p>
-	 * 
+	 *
 	 * @param monitor  to convert into a SubMonitor instance or null. If given a
 	 *                 null argument, the resulting SubMonitor will not report its
 	 *                 progress anywhere.
@@ -563,7 +563,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * <p>
 	 * This is a convenience method intended to reduce the boilerplate around code
 	 * which must call {@link #done()} on a possibly-null monitor.
-	 * 
+	 *
 	 * @param monitor a progress monitor or null
 	 * @since 3.8
 	 */
@@ -581,13 +581,13 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * instance. When this method is called, the remaining space on the progress
 	 * monitor is redistributed into the given number of ticks.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * It doesn't matter how much progress has already been reported with this
 	 * SubMonitor instance. If you call setWorkRemaining(100), you will be able to
 	 * report 100 more ticks of work before the progress meter reaches 100%.
 	 * </p>
-	 * 
+	 *
 	 * @param workRemaining total number of remaining ticks
 	 * @return the receiver
 	 */
@@ -626,7 +626,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	/**
 	 * Consumes the given number of child ticks, given as a double. Must only be
 	 * called if the monitor is in floating-point mode.
-	 * 
+	 *
 	 * @param ticks the number of ticks to consume
 	 * @return ticks the number of ticks to be consumed from parent
 	 */
@@ -669,7 +669,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * Checks whether cancellation of current operation has been requested and
 	 * throws an {@link OperationCanceledException} if it was the case. This method
 	 * is a shorthand for:
-	 * 
+	 *
 	 * <pre>
 	 * if (monitor.isCanceled())
 	 * 	throw new OperationCanceledException();
@@ -697,16 +697,16 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	/**
 	 * Starts a new main task. The string argument is ignored if and only if the
 	 * SUPPRESS_BEGINTASK flag has been set on this SubMonitor instance.
-	 * 
+	 *
 	 * <p>
 	 * This method is equivalent calling setWorkRemaining(...) on the receiver.
 	 * Unless the SUPPRESS_BEGINTASK flag is set, this will also be equivalent to
 	 * calling setTaskName(...) on the parent.
 	 * </p>
-	 * 
+	 *
 	 * @param name      new main task name
 	 * @param totalWork number of ticks to allocate
-	 * 
+	 *
 	 * @see org.eclipse.core.runtime.IProgressMonitor#beginTask(java.lang.String,
 	 *      int)
 	 */
@@ -776,13 +776,13 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * Creates a new SubMonitor that will consume the given number of ticks from its
 	 * parent. Shorthand for calling {@link #newChild(int, int)} with (totalWork,
 	 * SUPPRESS_BEGINTASK).
-	 * 
+	 *
 	 * <p>
 	 * This is much like {@link #split(int)} but it does not check for cancellation
 	 * and will not throw {@link OperationCanceledException}. New code should
 	 * consider using {@link #split(int)} to benefit from automatic cancellation
 	 * checks.
-	 * 
+	 *
 	 * @param totalWork number of ticks to consume from the receiver
 	 * @return new sub progress monitor that may be used in place of a new
 	 *         SubMonitor
@@ -796,7 +796,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * This is much like {@link #split}, but it does not check for cancellation and
 	 * will not throw {@link OperationCanceledException}. New code should consider
 	 * using {@link #split} to benefit from automatic cancellation checks.
-	 * 
+	 *
 	 * <p>
 	 * Creates a sub progress monitor that will consume the given number of ticks
 	 * from the receiver. It is not necessary to call <code>beginTask</code> or
@@ -804,36 +804,36 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * not report any work after the first call to done() or before ticks are
 	 * allocated. Ticks may be allocated by calling beginTask or setWorkRemaining.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Each SubMonitor only has one active child at a time. Each time newChild() is
 	 * called, the result becomes the new active child and any unused progress from
 	 * the previously-active child is consumed.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This is property makes it unnecessary to call done() on a SubMonitor
 	 * instance, since child monitors are automatically cleaned up the next time the
 	 * parent is touched.
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *  <code>
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 1: Typical usage of newChild
 	 *      void myMethod(IProgressMonitor parent) {
-	 *          SubMonitor progress = SubMonitor.convert(parent, 100); 
+	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
 	 *          doSomething(progress.newChild(50));
 	 *          doSomethingElse(progress.newChild(50));
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 2: Demonstrates the function of active children. Creating children
 	 *      // is sufficient to smoothly report progress, even if worked(...) and done()
 	 *      // are never called.
 	 *      void myMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          for (int i = 0; i &lt; 100; i++) {
 	 *              // Creating the next child monitor will clean up the previous one,
 	 *              // causing progress to be reported smoothly even if we don't do anything
@@ -841,27 +841,27 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 *          	progress.newChild(1);
 	 *          }
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 3: Demonstrates a common anti-pattern
 	 *      void wrongMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // WRONG WAY: Won't have the intended effect, as only one of these progress
 	 *          // monitors may be active at a time and the other will report no progress.
 	 *          callMethod(progress.newChild(50), computeValue(progress.newChild(50)));
 	 *      }
-	 *      
+	 *
 	 *      void rightMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // RIGHT WAY: Break up method calls so that only one SubMonitor is in use at a time.
 	 *          Object someValue = computeValue(progress.newChild(50));
 	 *          callMethod(progress.newChild(50), someValue);
 	 *      }
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param totalWork     number of ticks to consume from the receiver
 	 * @param suppressFlags a bitwise combination of SUPPRESS_* flags. They can be
 	 *                      used to suppress various behaviors on the newly-created
@@ -944,7 +944,7 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * This is shorthand for calling
 	 * <code>split(totalWork, SUPPRESS_BEGINTASK)</code>. See
 	 * {@link #split(int, int)} for more details.
-	 * 
+	 *
 	 * <p>
 	 * Creates a sub progress monitor that will consume the given number of ticks
 	 * from the receiver. It is not necessary to call <code>beginTask</code> or
@@ -953,44 +953,44 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * allocated. Ticks may be allocated by calling {@link #beginTask} or
 	 * {@link #setWorkRemaining}.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method is much like {@link #newChild}, but it will additionally check
 	 * for cancellation and will throw an OperationCanceledException if the monitor
 	 * has been cancelled. Not every call to this method will trigger a cancellation
 	 * check. The checks will be performed as often as possible without degrading
 	 * the performance of the caller.
-	 * 
+	 *
 	 * <p>
 	 * Each SubMonitor only has one active child at a time. Each time
 	 * {@link #newChild} or {@link #split} is called, the result becomes the new
 	 * active child and any unused progress from the previously-active child is
 	 * consumed.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This makes it unnecessary to call done() on a SubMonitor instance, since
 	 * child monitors are automatically cleaned up the next time the parent is
 	 * touched.
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 * <code>
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 1: Typical usage of split
 	 *      void myMethod(IProgressMonitor parent) {
-	 *          SubMonitor progress = SubMonitor.convert(parent, 100); 
+	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
 	 *          doSomething(progress.split(50));
 	 *          doSomethingElse(progress.split(50));
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 2: Demonstrates the function of active children. Creating children
 	 *      // is sufficient to smoothly report progress, even if worked(...) and done()
 	 *      // are never called.
 	 *      void myMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          for (int i = 0; i &lt; 100; i++) {
 	 *              // Creating the next child monitor will clean up the previous one,
 	 *              // causing progress to be reported smoothly even if we don't do anything
@@ -998,27 +998,27 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 *          	progress.split(1);
 	 *          }
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 3: Demonstrates a common anti-pattern
 	 *      void wrongMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // WRONG WAY: Won't have the intended effect, as only one of these progress
 	 *          // monitors may be active at a time and the other will report no progress.
 	 *          callMethod(progress.split(50), computeValue(progress.split(50)));
 	 *      }
-	 *      
+	 *
 	 *      void rightMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // RIGHT WAY: Break up method calls so that only one SubMonitor is in use at a time.
 	 *          Object someValue = computeValue(progress.split(50));
 	 *          callMethod(progress.split(50), someValue);
 	 *      }
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param totalWork number of ticks to consume from the receiver
 	 * @return a new SubMonitor instance
 	 * @throws OperationCanceledException if the monitor has been cancelled
@@ -1037,44 +1037,44 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 * allocated. Ticks may be allocated by calling {@link #beginTask} or
 	 * {@link #setWorkRemaining}
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This method is much like {@link #newChild}, but will additionally check for
 	 * cancellation and will throw an {@link OperationCanceledException} if the
 	 * monitor has been cancelled. Not every call to this method will trigger a
 	 * cancellation check. The checks will be performed as often as possible without
 	 * degrading the performance of the caller.
-	 * 
+	 *
 	 * <p>
 	 * Each SubMonitor only has one active child at a time. Each time
 	 * {@link #newChild} or {@link #split} is called, the result becomes the new
 	 * active child and any unused progress from the previously-active child is
 	 * consumed.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This is property makes it unnecessary to call done() on a SubMonitor
 	 * instance, since child monitors are automatically cleaned up the next time the
 	 * parent is touched.
 	 * </p>
-	 * 
+	 *
 	 * <pre>
 	 *  <code>
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 1: Typical usage of split
 	 *      void myMethod(IProgressMonitor parent) {
-	 *          SubMonitor progress = SubMonitor.convert(parent, 100); 
+	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
 	 *          doSomething(progress.split(50));
 	 *          doSomethingElse(progress.split(50));
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 2: Demonstrates the function of active children. Creating children
 	 *      // is sufficient to smoothly report progress, even if worked(...) and done()
 	 *      // are never called.
 	 *      void myMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          for (int i = 0; i &lt; 100; i++) {
 	 *              // Creating the next child monitor will clean up the previous one,
 	 *              // causing progress to be reported smoothly even if we don't do anything
@@ -1082,27 +1082,27 @@ public final class SubMonitor implements IProgressMonitorWithBlocking {
 	 *          	progress.split(1);
 	 *          }
 	 *      }
-	 *      
+	 *
 	 *      ////////////////////////////////////////////////////////////////////////////
 	 *      // Example 3: Demonstrates a common anti-pattern
 	 *      void wrongMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // WRONG WAY: Won't have the intended effect, as only one of these progress
 	 *          // monitors may be active at a time and the other will report no progress.
 	 *          callMethod(progress.split(50), computeValue(progress.split(50)));
 	 *      }
-	 *      
+	 *
 	 *      void rightMethod(IProgressMonitor parent) {
 	 *          SubMonitor progress = SubMonitor.convert(parent, 100);
-	 *          
+	 *
 	 *          // RIGHT WAY: Break up method calls so that only one SubMonitor is in use at a time.
 	 *          Object someValue = computeValue(progress.split(50));
 	 *          callMethod(progress.split(50), someValue);
 	 *      }
 	 * </code>
 	 * </pre>
-	 * 
+	 *
 	 * @param totalWork     number of ticks to consume from the receiver
 	 * @param suppressFlags a bitwise combination of SUPPRESS_* flags. They can be
 	 *                      used to suppress various behaviors on the newly-created

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SubProgressMonitor.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/SubProgressMonitor.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars.Vogel <Lars.Vogel@vogella.com> - Bug 479914
@@ -18,7 +18,7 @@ package org.eclipse.core.runtime;
  * A progress monitor that uses a given amount of work ticks from a parent
  * monitor. Code that currently uses this utility should be rewritten to use
  * {@link SubMonitor} instead. Consider the following example:
- * 
+ *
  * <pre>
  * void someMethod(IProgressMonitor pm) {
  * 	pm.beginTask("Main Task", 100);
@@ -38,7 +38,7 @@ package org.eclipse.core.runtime;
  * </pre>
  * <p>
  * The above code should be refactored to this:
- * 
+ *
  * <pre>
  * void someMethod(IProgressMonitor pm) {
  * 	SubMonitor subMonitor = SubMonitor.convert(pm, "Main Task", 100);
@@ -71,7 +71,7 @@ package org.eclipse.core.runtime;
  * <p>
  * This class may be instantiated or subclassed by clients.
  * </p>
- * 
+ *
  * @deprecated use {@link SubMonitor} instead
  */
 @Deprecated

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/runtime/URIUtil.java
@@ -20,7 +20,7 @@ import java.net.*;
  * A utility class for manipulating URIs. This class works around some of the
  * undesirable behavior of the {@link java.net.URI} class, and provides
  * additional path manipulation methods that are not available on the URI class.
- * 
+ *
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @since org.eclipse.equinox.common 3.5
  */
@@ -53,7 +53,7 @@ public final class URIUtil {
 	 * of the trailing slash depends on the existence of a local file on disk. This
 	 * method operates like a traditional path append and always preserves all
 	 * segments of the base path.
-	 * 
+	 *
 	 * @param base      The base URI to append to
 	 * @param extension The unencoded path extension to be added
 	 * @return The appended URI
@@ -110,7 +110,7 @@ public final class URIUtil {
 
 	/**
 	 * Ensures that UNC-Paths have at least four leading slashes.
-	 * 
+	 *
 	 * URI returns UNC-paths with two slashes, but needs four, when passing them as
 	 * path. See Java bug 4723726 or Eclipse bug 207103 for details
 	 */
@@ -144,7 +144,7 @@ public final class URIUtil {
 	 * URI specification. This method must not be called with a string that already
 	 * contains an encoded URI, since this will result in the URI escape character
 	 * ('%') being escaped itself.
-	 * 
+	 *
 	 * @param uriString An unencoded URI string
 	 * @return A URI corresponding to the given string
 	 * @throws URISyntaxException If the string cannot be formed into a valid URI
@@ -179,7 +179,7 @@ public final class URIUtil {
 
 	/**
 	 * Returns whether the given URI refers to a local file system URI.
-	 * 
+	 *
 	 * @param uri The URI to check
 	 * @return <code>true</code> if the URI is a local file system location, and
 	 *         <code>false</code> otherwise
@@ -235,7 +235,7 @@ public final class URIUtil {
 	 * Returns true if the two URIs are equal. URIs are considered equal if
 	 * {@link URI#equals(Object)} returns true, if the string representation of the
 	 * URIs is equal, or if they URIs are represent the same local file.
-	 * 
+	 *
 	 * @param uri1 The first URI to compare
 	 * @param uri2 The second URI to compare
 	 * @return <code>true</code> if the URIs are the same, and <code>false</code>
@@ -275,7 +275,7 @@ public final class URIUtil {
 	/**
 	 * Returns the URI as a local file, or <code>null</code> if the given URI does
 	 * not represent a local file.
-	 * 
+	 *
 	 * @param uri The URI to return the file for
 	 * @return The local file corresponding to the given URI, or <code>null</code>
 	 */
@@ -297,7 +297,7 @@ public final class URIUtil {
 	 * in a zip or jar file. If an entry path of <code>null</code> is provided, the
 	 * resulting URI will represent the jar file itself.
 	 * </p>
-	 * 
+	 *
 	 * @param uri       The URI of a zip or jar file
 	 * @param entryPath The path of a file inside the jar, or <code>null</code> to
 	 *                  obtain the URI for the jar file itself.
@@ -322,7 +322,7 @@ public final class URIUtil {
 	/**
 	 * Returns the URL as a URI. This method will handle URLs that are not properly
 	 * encoded (for example they contain unencoded space characters).
-	 * 
+	 *
 	 * @param url The URL to convert into a URI
 	 * @return A URI representing the given URL
 	 */
@@ -349,7 +349,7 @@ public final class URIUtil {
 
 	/**
 	 * An UNC-safe factory the the URI-ctor
-	 * 
+	 *
 	 * @param scheme   Scheme name
 	 * @param ssp      Scheme-specific part
 	 * @param fragment Fragment
@@ -368,7 +368,7 @@ public final class URIUtil {
 
 	/**
 	 * An UNC-safe factory the the URI-ctor
-	 * 
+	 *
 	 * @param scheme   Scheme name
 	 * @param userInfo User name and authorization information
 	 * @param host     Host name
@@ -395,7 +395,7 @@ public final class URIUtil {
 
 	/**
 	 * An UNC-safe factory the the URI-ctor
-	 * 
+	 *
 	 * @param scheme   Scheme name
 	 * @param host     Host name
 	 * @param path     Path
@@ -415,7 +415,7 @@ public final class URIUtil {
 
 	/**
 	 * An UNC-safe factory the the URI-ctor
-	 * 
+	 *
 	 * @param scheme    Scheme name
 	 * @param authority Authority
 	 * @param path      Path
@@ -440,7 +440,7 @@ public final class URIUtil {
 
 	/**
 	 * Returns a URI as a URL.
-	 * 
+	 *
 	 * <p>
 	 * Better use {@link URI#toURL()} instead.
 	 * </p>
@@ -453,7 +453,7 @@ public final class URIUtil {
 	 * Returns a string representation of the given URI that doesn't have illegal
 	 * characters encoded. This string is suitable for later passing to
 	 * {@link #fromString(String)}.
-	 * 
+	 *
 	 * @param uri The URI to convert to string format
 	 * @return An unencoded string representation of the URI
 	 */
@@ -481,7 +481,7 @@ public final class URIUtil {
 	 * {@link #makeRelative(URI, URI)}. That is, if R = makeRelative(O, B), then
 	 * makeAbsolute(R, B), will return the original URI O.
 	 * </p>
-	 * 
+	 *
 	 * @param relative the relative URI
 	 * @param baseURI  the base URI
 	 * @return an absolute URI
@@ -501,7 +501,7 @@ public final class URIUtil {
 	 * handling of file URIs. For file URIs, this method handles file system path
 	 * devices. If the URIs are not on the same device, then the original URI is
 	 * returned.
-	 * 
+	 *
 	 * @param original the original URI
 	 * @param baseURI  the base URI
 	 * @return a relative URI

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/core/text/StringMatcher.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/core/text/StringMatcher.java
@@ -359,7 +359,7 @@ public final class StringMatcher {
 		}
 		return i == segCount;
 	}
-	
+
 	/**
 	 * Similar to {@link #match(String)}, this methods matches a pattern that may
 	 * contain the wildcards '?' or '*' against a text. However, the matching is not
@@ -380,7 +380,7 @@ public final class StringMatcher {
 	 * <p>
 	 * An empty pattern matches only the empty text.
 	 * </p>
-	 * 
+	 *
 	 * @since 3.20
 	 */
 	public boolean matchWords(String text) {

--- a/bundles/org.eclipse.equinox.common/src/org/eclipse/equinox/events/MemoryEventConstants.java
+++ b/bundles/org.eclipse.equinox.common/src/org/eclipse/equinox/events/MemoryEventConstants.java
@@ -7,7 +7,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -34,7 +34,7 @@ package org.eclipse.equinox.events;
  * when to send memory events. This policy must use the Event Admin Service to
  * fire memory events to the registered handlers.
  * </p>
- * 
+ *
  * @since 3.6
  */
 public final class MemoryEventConstants {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

