### PR TITLE
Clean Code for bundles/org.eclipse.equinox.concurrent

### DIFF
--- a/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
@@ -10,5 +10,5 @@ Import-Package: org.eclipse.core.runtime;version="3.4.0";common=split,
  org.osgi.util.tracker
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
-Export-Package: org.eclipse.equinox.concurrent.future;version="1.1.0"
+Export-Package: org.eclipse.equinox.concurrent.future;version="1.1.0";uses:="org.eclipse.core.runtime"
 Automatic-Module-Name: org.eclipse.equinox.concurrent


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages

