### PR TITLE
Clean Code for bundles/org.eclipse.equinox.preferences

### DIFF
--- a/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences/META-INF/MANIFEST.MF
@@ -11,10 +11,9 @@ Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
  org.osgi.service.prefs;bundle-version="[1.1.0,1.2.0)";visibility:=reexport
 Export-Package: org.eclipse.core.internal.preferences;x-friends:="org.eclipse.core.resources,org.eclipse.core.runtime,org.eclipse.equinox.p2.engine",
  org.eclipse.core.internal.preferences.exchange;x-friends:="org.eclipse.core.runtime",
- org.eclipse.core.runtime.preferences;version="3.5.0";uses:="org.eclipse.core.runtime,org.osgi.service.prefs,org.eclipse.core.internal.preferences"
+ org.eclipse.core.runtime.preferences;version="3.5.0";uses:="org.eclipse.core.internal.preferences,org.eclipse.core.runtime,org.osgi.service.prefs"
 Bundle-ActivationPolicy: lazy; exclude:="org.eclipse.core.internal.preferences.exchange"
-Import-Package: org.eclipse.osgi.framework.log,
- org.eclipse.osgi.service.datalocation,
+Import-Package: org.eclipse.osgi.service.datalocation,
  org.eclipse.osgi.service.debug,
  org.eclipse.osgi.service.environment,
  org.eclipse.osgi.util,


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

