### PR TITLE
Clean Code for bundles/org.eclipse.equinox.security.tests

### DIFF
--- a/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.tests/META-INF/MANIFEST.MF
@@ -10,8 +10,7 @@ Require-Bundle: org.eclipse.core.tests.harness;bundle-version="3.4.0",
  org.junit,
  org.eclipse.osgi;bundle-version="3.4.0",
  org.eclipse.equinox.security;bundle-version="0.0.1",
- org.eclipse.equinox.registry;bundle-version="3.4.0",
- org.eclipse.equinox.preferences;bundle-version="3.2.200"
+ org.eclipse.equinox.registry;bundle-version="3.4.0"
 Export-Package: org.eclipse.equinox.internal.security.tests;x-internal:=true,
  org.eclipse.equinox.internal.security.tests.storage;x-internal:=true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

