### PR TITLE
Clean Code for bundles/org.eclipse.equinox.security.ui

### DIFF
--- a/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security.ui/META-INF/MANIFEST.MF
@@ -8,15 +8,12 @@ Bundle-Localization: plugin
 Import-Package: javax.crypto.spec,
  javax.security.auth.x500,
  org.eclipse.osgi.internal.provisional.service.security;version="[1.0.0,2.0.0)",
- org.eclipse.osgi.internal.service.security,
  org.eclipse.osgi.service.debug;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.security;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",
  org.osgi.framework;version="[1.6.0,2)",
  org.osgi.util.tracker;version="[1.5.0,2)"
 Require-Bundle: org.eclipse.equinox.security;bundle-version="[1.4.100,2.0.0)",
- org.eclipse.equinox.preferences;bundle-version="[3.2.200,4.0.0)",
- org.eclipse.swt;bundle-version="[3.118.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)"
 Bundle-Activator: org.eclipse.equinox.internal.security.ui.Activator


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

