### PR TITLE
Clean Code for bundles/org.eclipse.equinox.slf4j

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
+++ b/bundles/org.eclipse.equinox.slf4j/src/org/eclipse/equinox/slf4j/EquinoxLogger.java
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *     Christoph Läubrich - initial API and implementation
- *     IBM Corporation -  Update deprecated logger 
+ *     IBM Corporation -  Update deprecated logger
  *******************************************************************************/
 package org.eclipse.equinox.slf4j;
 
@@ -48,12 +48,12 @@ class EquinoxLogger extends org.slf4j.helpers.AbstractLogger {
 	public boolean isWarnEnabled() {
 		return logger != null && logger.isWarnEnabled();
 	}
-	
+
 	@Override
 	public boolean isErrorEnabled() {
 		return logger != null && logger.isErrorEnabled();
 	}
-	
+
 	@Override
 	public boolean isTraceEnabled(Marker marker) {
 		return isTraceEnabled();
@@ -86,11 +86,11 @@ class EquinoxLogger extends org.slf4j.helpers.AbstractLogger {
 
 	@Override
 	protected void handleNormalizedLoggingCall(Level level, Marker marker, String messagePattern, Object[] arguments,
-			Throwable throwable) {	
+			Throwable throwable) {
 		if (logger == null) {
 			return;
 		}
-		
+
 		if(level == Level.TRACE && logger.isTraceEnabled()) {
 			String formattedMessage = MessageFormatter.basicArrayFormat(messagePattern, arguments);
 			logger.trace(formattedMessage,throwable);


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

