### PR TITLE
Clean Code for bundles/org.eclipse.equinox.weaving.caching

### DIFF
--- a/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.weaving.caching/META-INF/MANIFEST.MF
@@ -6,9 +6,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Activator: org.eclipse.equinox.weaving.internal.caching.Activator
-Import-Package: com.ibm.oti.shared;resolution:=optional,
- org.eclipse.equinox.service.weaving,
- org.eclipse.osgi.service.datalocation;version="1.0.0",
+Import-Package: org.eclipse.equinox.service.weaving,
  org.eclipse.osgi.service.debug;version="1.0.0",
  org.osgi.framework;version="[1.5.0,2)"
 Export-Package: org.eclipse.equinox.weaving.internal.caching;x-friends:="org.aspectj.osgi.service.caching.test"


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

