### PR TITLE
Clean Code for bundles/org.eclipse.osgi.services

### DIFF
--- a/bundles/org.eclipse.osgi.services/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.services/META-INF/MANIFEST.MF
@@ -13,14 +13,3 @@ Export-Package: org.osgi.service.component.annotations;version="1.3",
 Import-Package: org.osgi.service.log;version="[1.5,1.6)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.osgi.services
-Require-Bundle: org.osgi.service.cm;bundle-version="[1.6.0,1.7.0)";visibility:=reexport,
- org.osgi.service.component;bundle-version="[1.5.0,1.6.0)";visibility:=reexport,
- org.osgi.service.device;bundle-version="[1.1.0,1.2.0)";visibility:=reexport,
- org.osgi.service.event;bundle-version="[1.4.0,1.5.0)";visibility:=reexport,
- org.osgi.service.metatype;bundle-version="[1.4.0,1.5.0)";visibility:=reexport,
- org.osgi.service.provisioning;bundle-version="[1.2.0,1.3.0)";visibility:=reexport,
- org.osgi.service.upnp;bundle-version="[1.2.0,1.3.0)";visibility:=reexport,
- org.osgi.service.useradmin;bundle-version="[1.1.0,1.2.0)";visibility:=reexport,
- org.osgi.service.wireadmin;bundle-version="[1.0.0,1.1.0)";visibility:=reexport,
- org.eclipse.equinox.http.service.api;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
- org.osgi.service.http.whiteboard;bundle-version="[1.1.0,2.0.0)";visibility:=reexport


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

