### PR TITLE
Clean Code for bundles/org.eclipse.osgi.util

### DIFF
--- a/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
@@ -10,8 +10,3 @@ Bundle-DocUrl: http://www.eclipse.org
 Bundle-ContactAddress: www.eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.osgi.util
-Require-Bundle: org.osgi.util.function;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
- org.osgi.util.promise;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
- org.osgi.util.measurement;bundle-version="[1.0.0,2.0.0)";visibility:=reexport,
- org.osgi.util.position;bundle-version="[1.0.0,2.0.0)";visibility:=reexport,
- org.osgi.util.xml;bundle-version="[1.0.0,2.0.0)";visibility:=reexport


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

