### PR TITLE
Clean Code for bundles/org.eclipse.equinox.bidi.tests

### DIFF
--- a/bundles/org.eclipse.equinox.bidi.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.bidi.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-Vendor: Eclipse.org - Equinox
 Bundle-SymbolicName: org.eclipse.equinox.bidi.tests;singleton:=true
 Bundle-Version: 1.4.300.qualifier
 Require-Bundle: org.eclipse.equinox.bidi;bundle-version="1.0.0",
- org.eclipse.equinox.registry;bundle-version="3.5.0",
  org.junit;bundle-version="4.12.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

