### PR TITLE
Clean Code for bundles/org.eclipse.equinox.cm.test

### DIFF
--- a/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.2.0.qualifier
 Import-Package: org.eclipse.core.runtime,
  org.eclipse.equinox.log,
  org.junit;version="4.12.0",
- org.junit.function;version="4.12.0",
  org.junit.runner;version="4.12.0",
  org.junit.runners;version="4.12.0",
  org.osgi.framework;version="1.3.0",
@@ -17,4 +16,3 @@ Import-Package: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.cm.test
-Require-Bundle: org.eclipse.equinox.cm


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

