### PR TITLE
Clean Code for bundles/org.eclipse.equinox.concurrent

### DIFF
--- a/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.concurrent/META-INF/MANIFEST.MF
@@ -5,9 +5,7 @@ Bundle-SymbolicName: org.eclipse.equinox.concurrent
 Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %pluginProvider
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.eclipse.core.runtime;version="3.4.0";common=split,
- org.osgi.framework;version="1.3.0",
- org.osgi.util.tracker
+Import-Package: org.eclipse.core.runtime;common=split;version="3.4.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.concurrent.future;version="1.1.0";uses:="org.eclipse.core.runtime"


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

