### PR TITLE
Clean Code for bundles/org.eclipse.equinox.console.ssh.tests

### DIFF
--- a/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.ssh.tests/META-INF/MANIFEST.MF
@@ -12,8 +12,6 @@ Import-Package: org.apache.sshd.client,
  org.apache.sshd.client.session,
  org.junit;version="4.8.1",
  org.mockito,
- org.mockito.stubbing,
- org.mockito.invocation,
  org.osgi.service.cm
 Fragment-Host: org.eclipse.equinox.console.ssh, org.eclipse.equinox.console
 Automatic-Module-Name: org.eclipse.equinox.console.ssh.tests


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

