### PR TITLE
Clean Code for bundles/org.eclipse.equinox.console.tests

### DIFF
--- a/bundles/org.eclipse.equinox.console.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console.tests/META-INF/MANIFEST.MF
@@ -6,11 +6,8 @@ Bundle-SymbolicName: org.eclipse.equinox.console.tests
 Bundle-Version: 1.3.100.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: org.apache.sshd.client.future,
- org.junit;version="4.8.1",
+Import-Package: org.junit;version="4.8.1",
  org.mockito,
- org.mockito.stubbing,
- org.mockito.invocation,
  org.osgi.service.cm
 Fragment-Host: org.eclipse.equinox.console
 Automatic-Module-Name: org.eclipse.equinox.console.tests


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

