### PR TITLE
Clean Code for bundles/org.eclipse.equinox.console

### DIFF
--- a/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.console/META-INF/MANIFEST.MF
@@ -23,7 +23,6 @@ Import-Package: org.apache.felix.service.command;version="[1.0,2.0)",
  org.osgi.service.condpermadmin;version="[1.1.0,2)",
  org.osgi.service.packageadmin,
  org.osgi.service.permissionadmin,
- org.osgi.service.startlevel,
  org.osgi.util.tracker;version="[1.5.0,2)"
 Export-Package: org.eclipse.equinox.console.common;uses:="org.apache.felix.service.command,org.osgi.framework",
  org.eclipse.equinox.console.common.terminal,


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

