### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.servlet.tests

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 1.9.400.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Require-Bundle: org.junit;bundle-version="4.0",
- org.apache.felix.scr,
  org.eclipse.equinox.http.jetty
 Import-Package: javax.servlet;version="2.6.0",
  javax.servlet.http;version="2.6.0",


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

