### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.servletbridge

### DIFF
--- a/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servletbridge/META-INF/MANIFEST.MF
@@ -6,8 +6,7 @@ Bundle-SymbolicName: org.eclipse.equinox.http.servletbridge;singleton:=true
 Bundle-Version: 1.3.200.qualifier
 Bundle-Activator: org.eclipse.equinox.http.servletbridge.internal.Activator
 Bundle-Localization: plugin
-Import-Package: javax.servlet.http;version="2.3",
- org.eclipse.equinox.http.servlet;version="1.0.0",
+Import-Package: org.eclipse.equinox.http.servlet;version="1.0.0",
  org.eclipse.equinox.servletbridge;version="[1.1.0,2)",
  org.osgi.framework;version="1.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

