### PR TITLE
Clean Code for bundles/org.eclipse.equinox.jsp.jasper.registry

### DIFF
--- a/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper.registry/META-INF/MANIFEST.MF
@@ -9,11 +9,8 @@ Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.registry.Activator
 Import-Package: org.eclipse.equinox.jsp.jasper,
  org.osgi.framework;version="1.3.0",
  org.osgi.service.packageadmin;version="1.2.0",
- org.osgi.util.tracker;version="[1.5.0,2)",
- javax.servlet;version="2.4",
- javax.servlet.http;version="2.4"
-Require-Bundle: org.eclipse.equinox.registry,
- org.eclipse.equinox.common
+ org.osgi.util.tracker;version="[1.5.0,2)"
+Require-Bundle: org.eclipse.equinox.registry
 Export-Package: org.eclipse.equinox.jsp.jasper.registry;version="1.0.0";uses:="org.eclipse.core.runtime"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

