### PR TITLE
Clean Code for bundles/org.eclipse.equinox.http.servlet

### DIFF
--- a/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.http.servlet/META-INF/MANIFEST.MF
@@ -18,7 +18,6 @@ Export-Package: org.eclipse.equinox.http.servlet;version="1.2.0";
  org.eclipse.equinox.http.servlet.dto;version="1.0.0";x-internal:=true,
  org.eclipse.equinox.http.servlet.session;version="1.0.0";x-internal:=true
 Import-Package: javax.servlet;version="[3.1.0,5.0.0)",
- javax.servlet.descriptor;version="[3.1.0,5.0.0)",
  javax.servlet.http;version="[3.1.0,5.0.0)",
  org.apache.commons.fileupload;version="[1.2.2,2.0.0)";resolution:=optional,
  org.apache.commons.fileupload.disk;version="[1.2.2,2.0.0)";resolution:=optional,


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

