### PR TITLE
Clean Code for bundles/org.eclipse.equinox.ds.tests

### DIFF
--- a/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.ds.tests/META-INF/MANIFEST.MF
@@ -7,14 +7,6 @@ Bundle-SymbolicName: org.eclipse.equinox.ds.tests
 Bundle-Version: 1.7.400.qualifier
 Bundle-Activator: org.eclipse.equinox.ds.tests.DSTestsActivator
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.junit
-Import-Package: 
- org.eclipse.osgi.service.urlconversion;version="1.0.0",
- org.osgi.framework;version="1.3.0",
- org.osgi.service.cm;version="1.2.0",
- org.osgi.service.component;version="1.0.0",
- org.osgi.service.permissionadmin;version="1.2.0",
- org.osgi.util.tracker;version="1.4.2"
 Export-Package: org.eclipse.equinox.ds.tests.tbc;uses:="org.osgi.framework,org.osgi.service.component"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

