### PR TITLE
Clean Code for bundles/org.eclipse.equinox.jsp.jasper

### DIFF
--- a/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.jsp.jasper/META-INF/MANIFEST.MF
@@ -6,9 +6,7 @@ Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.equinox.jsp.jasper
 Bundle-Version: 1.2.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.jsp.jasper.Activator
-Import-Package: com.sun.el;version="3.0.0",
- javax.servlet;version="[2.4,5.0)",
- javax.servlet.descriptor;version="[2.6.0,5.0.0)",
+Import-Package: javax.servlet;version="[2.4,5.0)",
  javax.servlet.http;version="[2.4,5.0)",
  org.apache.jasper.servlet;version="[9,10)",
  org.osgi.framework;version="[1.5.0,2)",


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

