### PR TITLE
Clean Code for bundles/org.eclipse.equinox.preferences.tests

### DIFF
--- a/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.preferences.tests/META-INF/MANIFEST.MF
@@ -5,16 +5,6 @@ Bundle-Vendor: Eclipse.org - Equinox
 Bundle-Category: test
 Bundle-SymbolicName: org.eclipse.equinox.preferences.tests
 Bundle-Version: 3.10.300.qualifier
-Require-Bundle: org.junit
-Import-Package: 
- org.eclipse.core.internal.preferences,
- org.eclipse.core.runtime;version="3.5.0",
- org.eclipse.core.runtime.jobs,
- org.eclipse.core.runtime.preferences;version="3.3.0",
- org.eclipse.osgi.service.datalocation;version="1.4.0",
- org.osgi.framework;version="1.3.0",
- org.osgi.service.prefs;version="1.1.1",
- org.osgi.util.tracker;version="1.4.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.equinox.preferences.tests


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

