### PR TITLE
Clean Code for bundles/org.eclipse.equinox.region

### DIFF
--- a/bundles/org.eclipse.equinox.region/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.region/META-INF/MANIFEST.MF
@@ -6,6 +6,11 @@ Bundle-Version: 1.5.800.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: system.bundle
 ExtensionBundle-Activator: org.eclipse.equinox.internal.region.RegionManager
-Export-Package: org.eclipse.equinox.region;version="1.2.0";uses:="org.osgi.framework,org.osgi.framework.wiring"
+Export-Package: org.eclipse.equinox.region;version="1.2.0";
+  uses:="org.osgi.framework,
+   org.osgi.framework.hooks.bundle,
+   org.osgi.framework.hooks.resolver,
+   org.osgi.framework.hooks.service,
+   org.osgi.framework.wiring"
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.equinox.region


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

