### PR TITLE
Clean Code for bundles/org.eclipse.equinox.security

### DIFF
--- a/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.security/META-INF/MANIFEST.MF
@@ -35,7 +35,6 @@ Import-Package: javax.crypto,
  org.eclipse.osgi.service.environment;version="[1.1.0,2.0.0)",
  org.eclipse.osgi.util;version="[1.1.0,2.0.0)",
  org.osgi.framework;version="[1.6.0,2)",
- org.osgi.service.prefs;version="[1.1.0,2.0.0)",
  org.osgi.util.tracker;version="[1.5.0,2)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

