### PR TITLE
Clean Code for bundles/org.eclipse.equinox.slf4j

### DIFF
--- a/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.slf4j/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Import-Package: org.eclipse.equinox.log;version="[1.1.0,2.0.0)",
  org.slf4j.event;version="[2.0.0,3.0.0)",
  org.slf4j.helpers;version="[2.0.0,3.0.0)",
  org.slf4j.spi;version="[2.0.0,3.0.0)"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.20.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.slf4j
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.equinox.slf4j.EquinoxLoggerFactoryActivator


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

