### PR TITLE
Clean Code for bundles/org.eclipse.equinox.cm.test

### DIFF
--- a/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.cm.test/META-INF/MANIFEST.MF
@@ -17,4 +17,3 @@ Import-Package: org.eclipse.core.runtime,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.equinox.cm.test
-Require-Bundle: org.eclipse.equinox.cm


### PR DESCRIPTION
### The following cleanups were applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove trailing white spaces on all lines
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Remove unused imports
- Remove unused private constructors
- Remove unused private fields
- Remove unused private methods
- Remove unused private types
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

### The following Manifest cleanups where applied:

- Calculate 'uses' directive for public packages
- Remove unused dependencies

